### PR TITLE
パスワードリセット機能の実装とUI調整（レスポンシブ対応）

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,51 @@
-<h2>Change your password</h2>
+<section class="bg-[#e9f7f7] min-h-[calc(100vh-80px)] flex items-center justify-center px-4">
+  <div class="w-full max-w-xl bg-white rounded-2xl shadow-sm px-6 py-10 md:px-10">
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+    <!-- タイトル -->
+    <h1 class="text-2xl md:text-3xl font-bold text-center mb-10">
+      新しいパスワード設定
+    </h1>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+    <%= form_for(resource, as: resource_name,
+          url: password_path(resource_name),
+          html: { method: :put }) do |f| %>
+
+      <%= f.hidden_field :reset_password_token %>
+
+      <!-- 新パスワード -->
+      <div class="mb-6 text-left">
+        <%= f.label :password, "新しいパスワード",
+              class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.password_field :password,
+              class: "w-full rounded-md border border-gray-300 px-4 py-2
+                      focus:outline-none focus:ring-2 focus:ring-cyan-300" %>
+      </div>
+
+      <!-- 確認 -->
+      <div class="mb-10 text-left">
+        <%= f.label :password_confirmation, "新しいパスワード（確認）",
+              class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.password_field :password_confirmation,
+              class: "w-full rounded-md border border-gray-300 px-4 py-2
+                      focus:outline-none focus:ring-2 focus:ring-cyan-300" %>
+      </div>
+
+      <!-- 変更ボタン -->
+      <div class="flex justify-center mb-10">
+        <%= f.submit "パスワードを変更",
+              class: "px-10 py-2 rounded-md bg-gray-200
+                      border border-gray-500 text-gray-800
+                      hover:bg-gray-300 transition" %>
+      </div>
+
     <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
-  </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
+    <!-- 下部リンク -->
+    <div class="flex justify-center text-sm text-gray-700">
+      <%= link_to "ログイン画面へ",
+            new_user_session_path,
+            class: "underline hover:text-gray-900" %>
+    </div>
 
-  <div class="actions">
-    <%= f.submit "Change my password" %>
   </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</section>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,46 @@
-<h2>Forgot your password?</h2>
+<section class="bg-[#e9f7f7] min-h-[calc(100vh-80px)] flex items-center justify-center px-4">
+  <div class="w-full max-w-xl bg-white rounded-2xl shadow-sm px-6 py-10 md:px-10">
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <!-- タイトル -->
+    <h1 class="text-2xl md:text-3xl font-bold text-center mb-10">
+      パスワード再設定
+    </h1>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <p class="text-sm text-gray-600 text-center mb-8">
+      ご登録のメールアドレスに<br class="md:hidden">
+      パスワード再設定用のリンクを送信します
+    </p>
+
+    <%= form_for(resource, as: resource_name,
+          url: password_path(resource_name),
+          html: { method: :post }) do |f| %>
+
+      <!-- メール -->
+      <div class="mb-10 text-left">
+        <%= f.label :email, "メールアドレス",
+              class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.email_field :email,
+              autofocus: true,
+              class: "w-full rounded-md border border-gray-300 px-4 py-2
+                      focus:outline-none focus:ring-2 focus:ring-cyan-300" %>
+      </div>
+
+      <!-- 送信ボタン -->
+      <div class="flex justify-center mb-10">
+        <%= f.submit "再設定メールを送信",
+              class: "px-10 py-2 rounded-md bg-gray-200
+                      border border-gray-500 text-gray-800
+                      hover:bg-gray-300 transition" %>
+      </div>
+
+    <% end %>
+
+    <!-- 下部リンク -->
+    <div class="flex justify-center text-sm text-gray-700">
+      <%= link_to "ログイン画面に戻る",
+            new_user_session_path,
+            class: "underline hover:text-gray-900" %>
+    </div>
+
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</section>


### PR DESCRIPTION
## 概要
Deviseを使用したパスワードリセット機能を実装しました。
既存のログイン・新規登録画面とUIを統一し、レスポンシブ対応済みです。

## 対応内容
- パスワードリセットメール送信画面（new）
- 新しいパスワード設定画面（edit）
- 既存認証画面（ログイン / 新規登録）と統一したUI
- スマホ・PC両対応のレスポンシブデザイン

## 実装背景
早期デプロイ前に最低限必要な認証機能を揃えるため、
後回し予定だったパスワードリセット機能を先行して実装しました。

## 動作確認
- [ ] パスワードリセットメールが送信される
- [ ] メール内リンクからパスワードを再設定できる
- [ ] 再設定後、正常にログインできる
- [ ] スマホ / PC 両方でレイアウト崩れがない

## 補足
- Devise標準機能を利用しており、独自ロジックは追加していません
- 文言やメール本文のカスタマイズは今後対応予定です
