### PR TITLE
feat: Couple と CoupleUser モデルを追加し ER 図通りに関連付けを実装

### DIFF
--- a/app/models/couple.rb
+++ b/app/models/couple.rb
@@ -1,0 +1,4 @@
+class Couple < ApplicationRecord
+  has_many :couple_users, dependent: :destroy
+  has_many :users, through: :couple_users
+end

--- a/app/models/couple_user.rb
+++ b/app/models/couple_user.rb
@@ -1,0 +1,6 @@
+class CoupleUser < ApplicationRecord
+  belongs_to :couple
+  belongs_to :user
+
+  validates :partner_nickname, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,8 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  # アソシエーション
+  has_many :couple_users, dependent: :destroy
+  has_many :couples, through: :couple_users
 end

--- a/db/migrate/20260114062829_create_couples.rb
+++ b/db/migrate/20260114062829_create_couples.rb
@@ -1,0 +1,7 @@
+class CreateCouples < ActiveRecord::Migration[8.1]
+  def change
+    create_table :couples do |t|
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260114062958_create_couple_users.rb
+++ b/db/migrate/20260114062958_create_couple_users.rb
@@ -1,0 +1,12 @@
+class CreateCoupleUsers < ActiveRecord::Migration[8.1]
+  def change
+    create_table :couple_users do |t|
+      t.references :couple, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.string :partner_nickname, null: false
+
+      t.timestamps
+    end
+    add_index :couple_users, [:couple_id, :user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_09_075103) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_14_062958) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "couple_users", force: :cascade do |t|
+    t.bigint "couple_id", null: false
+    t.datetime "created_at", null: false
+    t.string "partner_nickname", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["couple_id", "user_id"], name: "index_couple_users_on_couple_id_and_user_id", unique: true
+    t.index ["couple_id"], name: "index_couple_users_on_couple_id"
+    t.index ["user_id"], name: "index_couple_users_on_user_id"
+  end
+
+  create_table "couples", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -26,4 +42,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_09_075103) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "couple_users", "couples"
+  add_foreign_key "couple_users", "users"
 end

--- a/test/fixtures/couple_users.yml
+++ b/test/fixtures/couple_users.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/couples.yml
+++ b/test/fixtures/couples.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/couple_test.rb
+++ b/test/models/couple_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CoupleTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/couple_user_test.rb
+++ b/test/models/couple_user_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CoupleUserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
Couple / CoupleUser モデルを作成し、ER図通りのリレーションを実装しました。

## 変更内容
- Couple モデルを新規作成
- CoupleUser 中間テーブルモデルを作成
- User / Couple 間の多対多リレーションを実装
- partner_nickname を中間テーブルで管理できるように対応
- Rails console にて関連付けの動作確認を実施

## 関連モデル
- User
- Couple
- CoupleUser

## 動作確認
Rails console にて以下を確認済みです。

```ruby
u = User.first
c = Couple.create!

CoupleUser.create!(
  user: u,
  couple: c,
  partner_nickname: "大切な人"
)

u.couples
c.users
c.couple_users.first.partner_nickname
