### PR TITLE
招待コードuse画面のUI崩れ修正とi18n整理、ログイン後ナビゲーションをshared化

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Futari Logは同棲中や交際歴が長いカップルを主な対象として�
 
 ### デプロイ先
 - Render
+- Neon
 
 ### 使用予定のライブラリ
 - Tailwind CSS（レスポンシブ対応）
@@ -167,13 +168,10 @@ https://www.figma.com/design/fTG4X9fg7jQolInUe7zryh/project?node-id=0-1&p=f&t=d0
 ---
 
 ## ER図
-[![Image from Gyazo](https://i.gyazo.com/1b520101e2d045b2b00f6f6215916554.png)](https://gyazo.com/1b520101e2d045b2b00f6f6215916554)
+[![Image from Gyazo](https://i.gyazo.com/6bf1319bc75debd24b519991e049a831.png)](https://gyazo.com/6bf1319bc75debd24b519991e049a831)
 
 ## まとめ
 Futari Logは、  
 **自身の実体験から生まれた課題を、Webアプリとしてどう解決できるか**を追求した卒業制作です。
 
 技術だけでなく、UXや心理的負担への配慮を大切にしながら開発を進めます。
-
-## 画面遷移図
-https://www.figma.com/design/fTG4X9fg7jQolInUe7zryh/project?node-id=0-1&p=f&t=d0Lr8itl5FBzsJac-0

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,19 +1,6 @@
 <% if user_signed_in? %>
   <div class="bg-[#e9f7f7] min-h-screen flex overflow-hidden">
-
-    <!-- ===== サイドバー（PC） ===== -->
-    <aside class="hidden md:block w-64 bg-white shrink-0">
-      <nav class="flex flex-col h-full">
-        <div class="px-6 py-4 bg-cyan-100 font-semibold">
-          <%= current_user.nickname.presence || "自分のニックネーム" %>
-        </div>
-
-        <%= link_to "ごきげん記録", "#", class: "px-6 py-4 hover:bg-cyan-50" %>
-        <%= link_to "ありがとう記録", "#", class: "px-6 py-4 hover:bg-cyan-50" %>
-        <%= link_to "設定", "#", class: "px-6 py-4 hover:bg-cyan-50" %>
-      </nav>
-    </aside>
-
+  <%= render "shared/sidebar_user" %>
     <!-- ===== メイン＋スマホ用 ===== -->
     <div id="content-wrapper"
          class="flex-1 transition-transform duration-300">
@@ -61,26 +48,6 @@
         </div>
       </main>
     </div>
-
-    <!-- ===== スマホ用サイドバー ===== -->
-    <aside id="mobile-sidebar"
-      class="fixed left-0 top-[61px] h-[calc(100vh-61px)]
-             w-64 bg-white shadow-xl
-             transform -translate-x-full
-             transition-transform duration-300
-             z-40 md:hidden">
-
-      <nav class="flex flex-col h-full">
-        <div class="px-6 py-4 bg-cyan-100 font-semibold">
-          <%= current_user.nickname.presence || "自分のニックネーム" %>
-        </div>
-
-        <%= link_to "ごきげん記録", "#", class: "px-6 py-4 hover:bg-cyan-50" %>
-        <%= link_to "ありがとう記録", "#", class: "px-6 py-4 hover:bg-cyan-50" %>
-        <%= link_to "設定", "#", class: "px-6 py-4 hover:bg-cyan-50" %>
-      </nav>
-    </aside>
-
   </div>
 
 <% else %>

--- a/app/views/shared/_sidebar_user.html.erb
+++ b/app/views/shared/_sidebar_user.html.erb
@@ -1,0 +1,31 @@
+<!-- ===== サイドバー（PC） ===== -->
+<aside class="hidden md:block w-64 bg-white shrink-0">
+  <nav class="flex flex-col h-full">
+    <div class="px-6 py-4 bg-cyan-100 font-semibold">
+      <%= current_user.nickname.presence || "自分のニックネーム" %>
+    </div>
+
+    <%= link_to "ごきげん記録", "#", class: "px-6 py-4 hover:bg-cyan-50" %>
+    <%= link_to "ありがとう記録", "#", class: "px-6 py-4 hover:bg-cyan-50" %>
+    <%= link_to "設定", "#", class: "px-6 py-4 hover:bg-cyan-50" %>
+  </nav>
+</aside>
+
+<!-- ===== スマホ用サイドバー ===== -->
+<aside id="mobile-sidebar"
+  class="fixed left-0 top-[61px] h-[calc(100vh-61px)]
+         w-64 bg-white shadow-xl
+         transform -translate-x-full
+         transition-transform duration-300
+         z-40 md:hidden">
+
+  <nav class="flex flex-col h-full">
+    <div class="px-6 py-4 bg-cyan-100 font-semibold">
+      <%= current_user.nickname.presence || "自分のニックネーム" %>
+    </div>
+
+    <%= link_to "ごきげん記録", "#", class: "px-6 py-4 hover:bg-cyan-50" %>
+    <%= link_to "ありがとう記録", "#", class: "px-6 py-4 hover:bg-cyan-50" %>
+    <%= link_to "設定", "#", class: "px-6 py-4 hover:bg-cyan-50" %>
+  </nav>
+</aside>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -13,19 +13,19 @@ ja:
       enter: "招待コードを入力する"
 
   invitations:
-    title: "招待コード入力"
-    placeholder: "招待コードを入力してください"
-    submit: "つながる"
+    use:
+      title: "招待コード入力"
+      placeholder: "招待コードを入力してください"
+      submit: "つながる"
+      success: "カップル登録が完了しました"
 
-    success: "カップル登録が完了しました"
-
-    errors:
-      expired: "この招待コードは期限切れです"
-      used: "この招待コードはすでに使用されています"
-      unavailable: "この招待コードは使用できません"
-      self_use: "自分の招待コードは使用できません"
-      already_coupled: "すでにカップル設定があります"
-      not_found: "招待コードが見つかりません"
+      errors:
+        expired: "この招待コードは期限切れです"
+        used: "この招待コードはすでに使用されています"
+        unavailable: "この招待コードは使用できません"
+        self_use: "自分の招待コードは使用できません"
+        already_coupled: "すでにカップル設定があります"
+        not_found: "招待コードが見つかりません"
 
     new:
       title: "招待コード発行"


### PR DESCRIPTION
## 概要

UIの細かい調整と構造整理を行いました。
あわせて、招待コード参加機能で発生していた use 画面の表示崩れを修正しています。

次の機能開発（ごきげん記録）を見据えた、土台整理のための対応です。

---

## 対応内容

### UI / 表示修正
- 招待コード入力（use）画面の表示崩れを修正
- ja.yml のキー構造を整理し、翻訳参照ミスを解消
- 成功メッセージ・エラーメッセージが正しく表示されるよう修正

### 構造整理
- ログイン後トップページのナビゲーションを shared 化
  - PC / モバイル共通で再利用可能な構成に変更
- 今後追加予定の画面でも同一ナビゲーションを使い回せるように調整

### ドキュメント
- 最新の実装内容に合わせて ER 図を更新し、README に反映

---

## 変更ファイル（一部）

- `config/locales/ja.yml`
- `app/views/invitations/use.html.erb`
- `app/views/shared/_sidebar_user.html.erb`
- `app/views/home/index.html.erb`
- `README.md`

---

## 確認方法

1. 招待コード入力画面が正しく表示されること
2. 招待コード使用後、成功メッセージが表示されること
3. ログイン後トップページでナビゲーションが問題なく表示されること
4. モバイル / PC 両方でレイアウトが崩れていないこと

---

## 補足

- 機能的な挙動変更は行っておらず、主に UI・翻訳・構造整理を目的としています
- 次の issue で「ごきげん記録」画面を追加予定です
