### PR TITLE
ごきげん記録（moods）の投稿基盤を実装し、トップページUIとi18nを整備

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ https://www.figma.com/design/fTG4X9fg7jQolInUe7zryh/project?node-id=0-1&p=f&t=d0
 ---
 
 ## ER図
-[![Image from Gyazo](https://i.gyazo.com/6bf1319bc75debd24b519991e049a831.png)](https://gyazo.com/6bf1319bc75debd24b519991e049a831)
+[![Image from Gyazo](https://i.gyazo.com/b68124d335862332db67c9bb2f2ee7d8.png)](https://gyazo.com/b68124d335862332db67c9bb2f2ee7d8)
 
 ## まとめ
 Futari Logは、  

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,7 @@
 class HomeController < ApplicationController
   def index
+    return unless user_signed_in?
+
+    @today_mood = current_user.moods.find_by(recorded_on: Date.current)
   end
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -13,17 +13,17 @@ class InvitationsController < ApplicationController
     invitation = Invitation.find_by!(code: params[:code])
 
     unless invitation.available?
-      redirect_back fallback_location: couples_onboarding_path, alert: t("invitations.errors.unavailable")
+      redirect_back fallback_location: couples_onboarding_path, alert: t("invitations.use.errors.unavailable")
       return
     end
 
     if invitation.inviter == current_user
-      redirect_back fallback_location: couples_onboarding_path, alert: t("invitations.errors.self_use")
+      redirect_back fallback_location: couples_onboarding_path, alert: t("invitations.use.errors.self_use")
       return
     end
 
     if current_user.couples.exists?
-      redirect_to root_path, alert: t("invitations.errors.already_coupled")
+      redirect_to root_path, alert: t("invitations.use.errors.already_coupled")
       return
     end
 
@@ -47,7 +47,7 @@ class InvitationsController < ApplicationController
       )
     end
 
-    redirect_to root_path, notice: t("invitations.success")
+    redirect_to root_path, notice: t("invitations.use.success")
   end
 
   private

--- a/app/controllers/moods_controller.rb
+++ b/app/controllers/moods_controller.rb
@@ -1,0 +1,16 @@
+class MoodsController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    mood = current_user.moods.new(
+      level: params[:level],
+      recorded_on: Date.current
+    )
+
+    if mood.save
+      redirect_back fallback_location: root_path, notice: t("moods.create.success")
+    else
+      redirect_back fallback_location: root_path, alert: t("moods.create.already_recorded")
+    end
+  end
+end

--- a/app/helpers/moods_helper.rb
+++ b/app/helpers/moods_helper.rb
@@ -1,0 +1,2 @@
+module MoodsHelper
+end

--- a/app/models/mood.rb
+++ b/app/models/mood.rb
@@ -1,0 +1,14 @@
+class Mood < ApplicationRecord
+  belongs_to :user
+
+  enum :level, {
+    very_good: 5, # 🥰
+    good: 4,      # 🙂
+    neutral: 3,   # 😐
+    bad: 2,       # 😕
+    very_bad: 1   # 😢
+  }
+
+  validates :level, presence: true
+  validates :recorded_on, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,5 @@ class User < ApplicationRecord
   has_many :couple_users, dependent: :destroy
   has_many :couples, through: :couple_users
   has_many :invitations, foreign_key: :inviter_id, dependent: :destroy
+  has_many :moods, dependent: :destroy
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -22,27 +22,62 @@
           こんにちは、<%= current_user.nickname.presence || "◯◯" %>さん
         </h1>
 
-        <section class="bg-white rounded-2xl shadow-sm p-6 mb-10">
-          <h2 class="text-lg font-bold mb-4">今日のごきげんは？</h2>
-          <div class="flex justify-between text-4xl md:text-5xl">
-            😊 😐 😶 😟 😢
+        <section class="bg-white rounded-3xl shadow-sm p-10 md:p-14 mb-14">
+          <h2 class="text-xl font-bold mb-8">今日のごきげんは？</h2>
+
+          <div class="flex justify-between items-center">
+            <% {
+              very_good: "🥰",
+              good: "🙂",
+              neutral: "😐",
+              bad: "😕",
+              very_bad: "😢"
+            }.each do |level, emoji| %>
+
+              <% base_class =
+                "text-[56px] md:text-[72px] lg:text-[88px] transition transform"
+              %>
+
+              <% if @today_mood&.level == level.to_s %>
+                <!-- 選択済み -->
+                <span class="<%= base_class %> scale-110">
+                  <%= emoji %>
+                </span>
+
+              <% elsif @today_mood.present? %>
+                <!-- 他は非活性 -->
+                <span class="<%= base_class %> opacity-30">
+                  <%= emoji %>
+                </span>
+
+              <% else %>
+                <!-- 未選択 -->
+                <%= button_to moods_path(level: level),
+                      method: :post,
+                      form_class: "inline-block",
+                      class: "#{base_class} hover:scale-110 active:scale-100" do %>
+                  <%= emoji %>
+                <% end %>
+              <% end %>
+
+            <% end %>
           </div>
         </section>
 
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div class="bg-white rounded-2xl shadow-sm p-6">
-            <h3 class="font-bold mb-4">今週のごきげん傾向</h3>
-            <div class="flex items-center gap-6">
-              <span class="text-5xl">😊</span>
-              <span class="text-5xl font-bold">65%</span>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-10">
+          <div class="bg-white rounded-3xl shadow-sm p-10">
+            <h3 class="font-bold mb-6 text-lg">今週のごきげん傾向</h3>
+            <div class="flex items-center gap-8">
+              <span class="text-[64px] md:text-[80px]">😊</span>
+              <span class="text-[64px] md:text-[80px] font-bold">65%</span>
             </div>
           </div>
 
-          <div class="bg-white rounded-2xl shadow-sm p-6">
-            <h3 class="font-bold mb-4">今週もらったありがとう</h3>
-            <div class="flex items-center gap-4">
-              <span class="text-4xl">💌</span>
-              <span class="text-4xl font-bold">3件</span>
+          <div class="bg-white rounded-3xl shadow-sm p-10">
+            <h3 class="font-bold mb-6 text-lg">今週もらったありがとう</h3>
+            <div class="flex items-center gap-8">
+              <span class="text-[56px] md:text-[72px]">💌</span>
+              <span class="text-[56px] md:text-[72px] font-bold">3件</span>
             </div>
           </div>
         </div>

--- a/app/views/moods/create.html.erb
+++ b/app/views/moods/create.html.erb
@@ -1,0 +1,2 @@
+<h1>Moods#create</h1>
+<p>Find me in app/views/moods/create.html.erb</p>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -32,3 +32,8 @@ ja:
       description: "パートナーにこのコードを伝えてください"
       copy: "コピーしてください"
       expires_at: "有効期限: %{time}"
+
+  moods:
+    create:
+      success: "ごきげんを記録しました"
+      already_recorded: "本日はすでに記録済みです"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get "moods/create"
   root "home#index"
   devise_for :users
   # 招待コード発行
@@ -11,6 +12,7 @@ Rails.application.routes.draw do
   end
 
   resources :invitations, only: [ :new, :create ]
+  resources :moods, only: [ :create ]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20260119032407_create_moods.rb
+++ b/db/migrate/20260119032407_create_moods.rb
@@ -1,0 +1,13 @@
+class CreateMoods < ActiveRecord::Migration[8.1]
+  def change
+    create_table :moods do |t|
+      t.references :user, null: false, foreign_key: true
+      t.integer :level, null: false
+      t.date :recorded_on, null: false
+
+      t.timestamps
+    end
+    
+    add_index :moods, [:user_id, :recorded_on], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_16_031148) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_19_032407) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -43,6 +43,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_16_031148) do
     t.index ["inviter_id"], name: "index_invitations_on_inviter_id"
   end
 
+  create_table "moods", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "level", null: false
+    t.date "recorded_on", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id", "recorded_on"], name: "index_moods_on_user_id_and_recorded_on", unique: true
+    t.index ["user_id"], name: "index_moods_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email", default: "", null: false
@@ -60,4 +70,5 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_16_031148) do
   add_foreign_key "couple_users", "users"
   add_foreign_key "invitations", "couples"
   add_foreign_key "invitations", "users", column: "inviter_id"
+  add_foreign_key "moods", "users"
 end

--- a/test/controllers/moods_controller_test.rb
+++ b/test/controllers/moods_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class MoodsControllerTest < ActionDispatch::IntegrationTest
+  test "should get create" do
+    get moods_create_url
+    assert_response :success
+  end
+end

--- a/test/fixtures/moods.yml
+++ b/test/fixtures/moods.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  level: 1
+  recorded_on: 2026-01-19
+
+two:
+  user: two
+  level: 1
+  recorded_on: 2026-01-19

--- a/test/models/mood_test.rb
+++ b/test/models/mood_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MoodTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
ごきげん記録（投稿基盤）の作成を行いました。
あわせて、ログイン後トップページのUI調整および文言のi18n対応を行っています。

## 実装内容

### ごきげん記録（投稿基盤）
- moods テーブルを作成
- ごきげんレベルを5段階（🥰 🙂 😐 😕 😢）で保存
- user_id + recorded_on に UNIQUE 制約を設定し、1日1回のみ記録可能に
- ワンタップでごきげんを投稿できるUIを実装
- 一度記録したごきげんは編集・過去入力不可とした

### ログイン後トップページ
- 「今日のごきげんは？」セクションを実装
  - 未記録時：ごきげんを選択可能
  - 記録済み時：選択したごきげんのみ強調表示、他は非活性表示
- 今週のごきげん傾向／今週もらったありがとう の表示UIを調整
- デザインが意図した見た目になるよう余白・サイズ感を調整
- レスポンシブ対応（PC / スマホ）を維持

### その他
- フラッシュメッセージや表示文言を ja.yml に移動
- ログアウト時にエラーが発生しないよう、Controller 側で認証ガードを追加

## 動作確認
- ログイン状態でごきげんをワンタップ投稿できること
- 同日に2回以上投稿できないこと
- 記録済みの場合、選択状態が正しく表示されること
- ログアウト時にエラーが発生しないこと

## 補足
- 今回は「ごきげん記録の投稿基盤」までを対象としています
- ごきげんの集計（週間平均・パートナー表示）は次 issue で対応予定です