### PR TITLE
自分の1週間分ごきげん履歴表示と傾向％算出を追加

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,5 +3,19 @@ class HomeController < ApplicationController
     return unless user_signed_in?
 
     @today_mood = current_user.moods.find_by(recorded_on: Date.current)
+
+    @week_dates = (Date.current - 6.days..Date.current).to_a
+
+    moods = current_user.moods
+              .where(recorded_on: @week_dates)
+              .to_a
+              .index_by { |m| m.recorded_on.to_date }
+
+    @weekly_scores = @week_dates.map do |date|
+      moods[date]&.score || 50
+    end
+
+    @weekly_average = (@weekly_scores.sum / 7.0).round
+    @weekly_level = Mood.level_from_average(@weekly_average)
   end
 end

--- a/app/controllers/moods_controller.rb
+++ b/app/controllers/moods_controller.rb
@@ -1,6 +1,16 @@
 class MoodsController < ApplicationController
   before_action :authenticate_user!
 
+  def index
+    @week_dates = (Date.current - 6.days..Date.current).to_a.reverse
+
+    moods = current_user.moods.where(recorded_on: @week_dates).index_by(&:recorded_on)
+
+    @weekly_moods = @week_dates.map do |date|
+      [ date, moods[date]&.level || "neutral" ]
+    end
+  end
+
   def create
     mood = current_user.moods.new(
       level: params[:level],

--- a/app/helpers/moods_helper.rb
+++ b/app/helpers/moods_helper.rb
@@ -1,2 +1,23 @@
 module MoodsHelper
+  def mood_emoji(level)
+    {
+      "very_good" => "🥰",
+      "good"      => "🙂",
+      "neutral"   => "😐",
+      "bad"       => "😕",
+      "very_bad"  => "😢"
+    }[level]
+  end
+
+  def date_label(date)
+    return "" if date.blank?
+
+    date = date.to_date
+
+    return "今日" if date == Date.current
+    return "昨日" if date == Date.current - 1
+
+    days_ago = (Date.current - date).to_i
+    "#{days_ago}日前"
+  end
 end

--- a/app/models/mood.rb
+++ b/app/models/mood.rb
@@ -9,6 +9,30 @@ class Mood < ApplicationRecord
     very_bad: 1   # 😢
   }
 
+  SCORE_MAP = {
+    very_good: 100,
+    good: 75,
+    neutral: 50,
+    bad: 25,
+    very_bad: 0
+  }
+
+  LEVEL_BY_SCORE = [
+    { min: 80, level: "very_good" },
+    { min: 60, level: "good" },
+    { min: 40, level: "neutral" },
+    { min: 20, level: "bad" },
+    { min: 0,  level: "very_bad" }
+  ]
+
+  def self.level_from_average(score)
+    LEVEL_BY_SCORE.find { |rule| score >= rule[:min] }[:level]
+  end
+
+  def score
+    SCORE_MAP[level.to_sym]
+  end
+
   validates :level, presence: true
   validates :recorded_on, presence: true
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -68,8 +68,8 @@
           <div class="bg-white rounded-3xl shadow-sm p-10">
             <h3 class="font-bold mb-6 text-lg">今週のごきげん傾向</h3>
             <div class="flex items-center gap-8">
-              <span class="text-[64px] md:text-[80px]">😊</span>
-              <span class="text-[64px] md:text-[80px] font-bold">65%</span>
+              <span class="text-[64px] md:text-[80px]"><%= mood_emoji(@weekly_level) %></span>
+              <span class="text-[64px] md:text-[80px] font-bold"><%= @weekly_average %>%</span>
             </div>
           </div>
 

--- a/app/views/moods/index.html.erb
+++ b/app/views/moods/index.html.erb
@@ -1,0 +1,42 @@
+<% if user_signed_in? %>
+  <div class="bg-[#e9f7f7] min-h-screen flex overflow-hidden">
+    <%= render "shared/sidebar_user" %>
+
+    <div id="content-wrapper" class="flex-1 transition-transform duration-300">
+      <main class="px-4 md:px-10 py-8 max-w-full overflow-x-hidden">
+
+        <!-- ☰（スマホ） -->
+        <div class="md:hidden mb-6">
+          <button id="sidebar-toggle"
+            class="flex items-center gap-2 border border-gray-300 rounded-lg px-3 py-2 bg-white shadow-sm text-gray-700">
+            <span class="text-xl">☰</span>
+            <span class="text-sm">メニュー</span>
+          </button>
+        </div>
+
+        <h1 class="text-xl md:text-2xl font-bold mb-8">
+          <%= current_user.nickname %>さんの今週のごきげん傾向
+        </h1>
+
+        <!-- ===== 1週間のごきげん ===== -->
+        <section class="bg-white rounded-3xl shadow-sm p-10 md:p-14 mb-14">
+          <div class="grid grid-cols-7 gap-4 text-center">
+
+            <% @weekly_moods.each do |date, level| %>
+              <div>
+                <div class="text-sm text-gray-500 mb-2">
+                  <%= date_label(date) %>
+                </div>
+                <div class="text-[40px] md:text-[56px]">
+                  <%= mood_emoji(level) %>
+                </div>
+              </div>
+            <% end %>
+
+          </div>
+        </section>
+
+      </main>
+    </div>
+  </div>
+<% end %>

--- a/app/views/shared/_sidebar_user.html.erb
+++ b/app/views/shared/_sidebar_user.html.erb
@@ -2,10 +2,12 @@
 <aside class="hidden md:block w-64 bg-white shrink-0">
   <nav class="flex flex-col h-full">
     <div class="px-6 py-4 bg-cyan-100 font-semibold">
-      <%= current_user.nickname.presence || "自分のニックネーム" %>
+      <%= link_to current_user.nickname.presence || "自分のニックネーム",
+                  root_path,
+                  class: "block hover:underline" %>
     </div>
 
-    <%= link_to "ごきげん記録", "#", class: "px-6 py-4 hover:bg-cyan-50" %>
+    <%= link_to "ごきげん記録", moods_path, class: "px-6 py-4 hover:bg-cyan-50" %>
     <%= link_to "ありがとう記録", "#", class: "px-6 py-4 hover:bg-cyan-50" %>
     <%= link_to "設定", "#", class: "px-6 py-4 hover:bg-cyan-50" %>
   </nav>
@@ -21,7 +23,9 @@
 
   <nav class="flex flex-col h-full">
     <div class="px-6 py-4 bg-cyan-100 font-semibold">
-      <%= current_user.nickname.presence || "自分のニックネーム" %>
+      <%= link_to current_user.nickname.presence || "自分のニックネーム",
+                  root_path,
+                  class: "block hover:underline" %>
     </div>
 
     <%= link_to "ごきげん記録", "#", class: "px-6 py-4 hover:bg-cyan-50" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   end
 
   resources :invitations, only: [ :new, :create ]
-  resources :moods, only: [ :create ]
+  resources :moods, only: [ :create, :index ]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20260119032407_create_moods.rb
+++ b/db/migrate/20260119032407_create_moods.rb
@@ -7,7 +7,7 @@ class CreateMoods < ActiveRecord::Migration[8.1]
 
       t.timestamps
     end
-    
-    add_index :moods, [:user_id, :recorded_on], unique: true
+
+    add_index :moods, [ :user_id, :recorded_on ], unique: true
   end
 end


### PR DESCRIPTION
## 概要

Issue②「自分のごきげん履歴表示」に対応し、  
ユーザー自身の1週間分のごきげん履歴と傾向を確認できる機能を実装しました。

あわせて、サイドバーの自分のニックネームをクリックすると
`root_path` に遷移するようにしています。

---

## 対応内容

### ✅ 実装したこと
- 新しい「ごきげん記録ページ」を作成
- 自分の **直近1週間分のごきげんを絵文字で表示**
- ログイン後トップページに **今週のごきげん傾向（％）を表示**
- 未記入日は 😐（50点）として計算する仕様を実装
- サイドバーの自分のニックネーム押下で `root_path` に遷移するよう修正

### ❌ 今回対応していないこと
- パートナーのごきげん表示・集計
- ダッシュボード全体の大規模な改修
- 週以外（月・年など）の集計拡張

---

## 仕様補足

- 1週間は「今日を含む過去7日間」
- ごきげんスコアの対応関係  
  - 🥰 very_good : 100  
  - 🙂 good : 75  
  - 😐 neutral / 未記入 : 50  
  - 😕 bad : 25  
  - 😢 very_bad : 0  
- ごきげん傾向（%）は7日分の平均値を算出

---

## 確認方法

1. ログインする
2. トップページで「今週のごきげん傾向（%）」が表示されることを確認
3. サイドバーの自分のニックネームをクリックし、トップページに遷移することを確認
4. ごきげん記録ページで、1週間分の絵文字表示を確認

---

## 関連Issue

- Issue②：自分のごきげん履歴と傾向表示
