### PR TITLE
ありがとう投稿機能の初期実装

### DIFF
--- a/app/controllers/thanks_controller.rb
+++ b/app/controllers/thanks_controller.rb
@@ -1,0 +1,29 @@
+class ThanksController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    # @received_thanks = Thanks.where(receiver: current_user).order(created_at: :desc)
+  end
+
+  def new
+    @thanks = Thank.new
+  end
+
+  def create
+    @thanks = Thank.new
+    @thanks.sender = current_user
+    @thanks.receiver = partner_user
+
+    if @thanks.save
+      redirect_to thanks_path, notice: t("thanks.create.success")
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def partner_user
+    current_user.partner
+  end
+end

--- a/app/helpers/thanks_helper.rb
+++ b/app/helpers/thanks_helper.rb
@@ -1,0 +1,2 @@
+module ThanksHelper
+end

--- a/app/models/thank.rb
+++ b/app/models/thank.rb
@@ -1,0 +1,22 @@
+class Thank < ApplicationRecord
+  belongs_to :sender, class_name: "User"
+  belongs_to :receiver, class_name: "User"
+
+  validates :sender, presence: true
+  validates :receiver, presence: true
+  validate :sender_and_receiver_are_different
+  validate :same_couple_only
+
+  private
+
+  def sender_and_receiver_are_different
+    errors.add(:receiver, :same_as_sender) if sender_id == receiver_id
+  end
+
+  def same_couple_only
+    return if sender.blank? || receiver.blank?
+    return if sender.couples.first == receiver.couples.first
+
+    errors.add(:receiver, :not_same_couple)
+  end
+end

--- a/app/views/shared/_sidebar_user.html.erb
+++ b/app/views/shared/_sidebar_user.html.erb
@@ -8,7 +8,7 @@
     </div>
 
     <%= link_to "ごきげん記録", moods_path, class: "px-6 py-4 hover:bg-cyan-50" %>
-    <%= link_to "ありがとう記録", "#", class: "px-6 py-4 hover:bg-cyan-50" %>
+    <%= link_to "ありがとう記録", thanks_path, class: "px-6 py-4 hover:bg-cyan-50" %>
     <%= link_to "設定", "#", class: "px-6 py-4 hover:bg-cyan-50" %>
   </nav>
 </aside>
@@ -28,8 +28,8 @@
                   class: "block hover:underline" %>
     </div>
 
-    <%= link_to "ごきげん記録", "#", class: "px-6 py-4 hover:bg-cyan-50" %>
-    <%= link_to "ありがとう記録", "#", class: "px-6 py-4 hover:bg-cyan-50" %>
+    <%= link_to "ごきげん記録", moods_path, class: "px-6 py-4 hover:bg-cyan-50" %>
+    <%= link_to "ありがとう記録", thanks_path, class: "px-6 py-4 hover:bg-cyan-50" %>
     <%= link_to "設定", "#", class: "px-6 py-4 hover:bg-cyan-50" %>
   </nav>
 </aside>

--- a/app/views/thanks/index.html.erb
+++ b/app/views/thanks/index.html.erb
@@ -1,0 +1,84 @@
+<% if user_signed_in? %>
+  <div class="bg-[#e9f7f7] min-h-screen flex overflow-hidden">
+    <%= render "shared/sidebar_user" %>
+
+    <div id="content-wrapper" class="flex-1 transition-transform duration-300">
+      <main class="px-4 md:px-10 py-8 max-w-full overflow-x-hidden">
+
+        <!-- ☰（スマホ） -->
+        <div class="md:hidden mb-6">
+          <button id="sidebar-toggle"
+            class="flex items-center gap-2 border border-gray-300 rounded-lg px-3 py-2 bg-white shadow-sm text-gray-700">
+            <span class="text-xl">☰</span>
+            <span class="text-sm">メニュー</span>
+          </button>
+        </div>
+
+        <h1 class="text-xl md:text-2xl font-bold mb-6">
+          <%= current_user.nickname %>さんのありがとう記録
+        </h1>
+
+        <!-- ===== 上段：送る＋一覧 ===== -->
+        <section class="bg-white rounded-3xl shadow-sm p-8 md:p-9 mb-14">
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
+
+            <!-- 左：ありがとうを贈る -->
+            <div class="flex flex-col items-center justify-center mt-15">
+              <%= link_to t("thanks.dashboard.send"),
+                    new_thank_path,
+                    class: "px-8 py-4 rounded-full bg-pink-500 text-white font-bold text-lg hover:bg-pink-600 transition mb-6" %>
+
+              <p class="text-gray-500 text-sm text-center">
+                相手に感謝を届けましょう
+              </p>
+            </div>
+
+            <!-- 右：もらったありがとう一覧（空・スクロール） -->
+            <div>
+              <h3 class="font-bold mb-4">
+                もらったありがとう
+              </h3>
+
+              <div class="border rounded-xl p-4 h-48 overflow-y-auto text-sm text-gray-400 space-y-2">
+                <!-- ダミー（後で each に差し替え） -->
+                <p>・ありがとうがここに表示されます</p>
+                <p>・日付 + タグ表示予定</p>
+                <p>・増えるとスクロールできます</p>
+              </div>
+            </div>
+
+          </div>
+        </section>
+
+        <h3 class="font-bold mb-6 text-lg">
+          ありがとう集計
+        </h3>
+
+        <!-- ===== 下段：グラフ＆件数 ===== -->
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-10">
+
+          <div class="bg-white rounded-3xl shadow-sm p-10">
+            <h3 class="font-bold mb-6 text-lg">
+              週別受け取ったありがとうグラフ
+            </h3>
+            <p class="text-gray-400 text-sm">
+              ※ グラフは後で実装
+            </p>
+          </div>
+
+          <div class="bg-white rounded-3xl shadow-sm p-10">
+            <h3 class="font-bold mb-6 text-lg">
+              今週贈ったありがとう
+            </h3>
+            <div class="flex items-center gap-6">
+              <span class="text-[56px] md:text-[72px]">💌</span>
+              <span class="text-[56px] md:text-[72px] font-bold">3件</span>
+            </div>
+          </div>
+
+        </div>
+      </main>
+    </div>
+  </div>
+<% end %>
+

--- a/app/views/thanks/new.html.erb
+++ b/app/views/thanks/new.html.erb
@@ -1,0 +1,38 @@
+<% if user_signed_in? %>
+  <div class="bg-[#e9f7f7] min-h-screen flex overflow-hidden">
+    <%= render "shared/sidebar_user" %>
+
+    <div id="content-wrapper" class="flex-1 transition-transform duration-300">
+      <main class="px-4 md:px-10 py-8 max-w-full overflow-x-hidden">
+
+        <!-- ☰（スマホ） -->
+        <div class="md:hidden mb-6">
+          <button id="sidebar-toggle"
+            class="flex items-center gap-2 border border-gray-300 rounded-lg px-3 py-2 bg-white shadow-sm text-gray-700">
+            <span class="text-xl">☰</span>
+            <span class="text-sm">メニュー</span>
+          </button>
+        </div>
+
+        <section class="max-w-2xl mx-auto bg-white rounded-3xl shadow-sm px-6 py-10 md:px-10">
+          <h1 class="text-2xl md:text-3xl font-bold text-center mb-8">
+            <%= t("thanks.new.title") %>
+          </h1>
+
+          <p class="text-center text-gray-700 mb-10">
+            <%= t("thanks.new.description") %>
+          </p>
+
+          <div class="text-center">
+            <%= button_to t("thanks.new.submit"),
+                  thanks_path,
+                  method: :post,
+                  class: "px-10 py-4 rounded-full bg-pink-500 text-white font-bold text-lg hover:bg-pink-600 transition" %>
+          </div>
+        </section>
+
+      </main>
+    </div>
+  </div>
+<% end %>
+

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -37,3 +37,23 @@ ja:
     create:
       success: "ごきげんを記録しました"
       already_recorded: "本日はすでに記録済みです"
+
+  activerecord:
+    errors:
+      models:
+        thanks:
+          attributes:
+            receiver:
+              same_as_sender: "自分自身にありがとうは送れません"
+              not_same_couple: "パートナー以外には送れません"
+
+  thanks:
+    dashboard:
+      title: "ありがとう記録"
+      send: "🌸 ありがとうを贈る 🌸"
+    new:
+      title: "ありがとうを贈る"
+      description: "ワンタップで気持ちを届けましょう"
+      submit: "🌸 ありがとうを贈る 🌸"
+    create:
+      success: "ありがとうを贈りました 💐"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
 
   resources :invitations, only: [ :new, :create ]
   resources :moods, only: [ :create, :index ]
+  resources :thanks, only: [ :new, :create, :index ]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20260122052043_create_thanks.rb
+++ b/db/migrate/20260122052043_create_thanks.rb
@@ -1,0 +1,10 @@
+class CreateThanks < ActiveRecord::Migration[8.1]
+  def change
+    create_table :thanks do |t|
+      t.references :sender, null: false, foreign_key: { to_table: :users }
+      t.references :receiver, null: false, foreign_key: { to_table: :users }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_19_032407) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_22_052043) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -53,6 +53,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_19_032407) do
     t.index ["user_id"], name: "index_moods_on_user_id"
   end
 
+  create_table "thanks", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "receiver_id", null: false
+    t.bigint "sender_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["receiver_id"], name: "index_thanks_on_receiver_id"
+    t.index ["sender_id"], name: "index_thanks_on_sender_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email", default: "", null: false
@@ -71,4 +80,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_19_032407) do
   add_foreign_key "invitations", "couples"
   add_foreign_key "invitations", "users", column: "inviter_id"
   add_foreign_key "moods", "users"
+  add_foreign_key "thanks", "users", column: "receiver_id"
+  add_foreign_key "thanks", "users", column: "sender_id"
 end

--- a/test/controllers/thanks_controller_test.rb
+++ b/test/controllers/thanks_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ThanksControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/thanks.yml
+++ b/test/fixtures/thanks.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  sender: one
+  receiver: one
+
+two:
+  sender: two
+  receiver: two

--- a/test/models/thank_test.rb
+++ b/test/models/thank_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ThankTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
ありがとう投稿機能（MVP Issue 1）を実装しました。

## 実装内容
- thanks テーブル作成
- sender / receiver（User）関連付け
- カップル内限定のバリデーション
- 自分宛送信不可の制御
- ありがとう送信ページ（仮完成）
- ダッシュボードに「ありがとうを贈る」ボタン設置

## 補足
- タグ機能は未実装（Issue 3 で対応予定）
- 一覧・グラフ表示はダミー表示のみ