### PR TITLE
タグ機能の最小構成を実装

### DIFF
--- a/app/controllers/thanks_controller.rb
+++ b/app/controllers/thanks_controller.rb
@@ -2,26 +2,34 @@ class ThanksController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    # @received_thanks = Thanks.where(receiver: current_user).order(created_at: :desc)
+    @received_thanks = Thank.where(receiver: current_user).includes(:tag, :sender).order(created_at: :desc)
   end
 
   def new
     @thanks = Thank.new
+    @tags = Tag.all
   end
 
   def create
-    @thanks = Thank.new
+    @thanks = Thank.new(thank_params)
     @thanks.sender = current_user
     @thanks.receiver = partner_user
+    @tags = Tag.all
 
     if @thanks.save
       redirect_to thanks_path, notice: t("thanks.create.success")
     else
+      @tags = Tag.all
+      flash.now[:alert] = t("thanks.create.failure")
       render :new, status: :unprocessable_entity
     end
   end
 
   private
+
+  def thank_params
+    params.require(:thank).permit(:tag_id)
+  end
 
   def partner_user
     current_user.partner

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,5 @@
+class Tag < ApplicationRecord
+  has_many :thanks, dependent: :restrict_with_exception
+
+  validates :name, presence: true
+end

--- a/app/models/thank.rb
+++ b/app/models/thank.rb
@@ -1,9 +1,11 @@
 class Thank < ApplicationRecord
   belongs_to :sender, class_name: "User"
   belongs_to :receiver, class_name: "User"
+  belongs_to :tag
 
   validates :sender, presence: true
   validates :receiver, presence: true
+  validates :tag, presence: true
   validate :sender_and_receiver_are_different
   validate :same_couple_only
 

--- a/app/views/thanks/new.html.erb
+++ b/app/views/thanks/new.html.erb
@@ -19,20 +19,50 @@
             <%= t("thanks.new.title") %>
           </h1>
 
-          <p class="text-center text-gray-700 mb-10">
+          <p class="text-center text-gray-700 mb-8">
             <%= t("thanks.new.description") %>
           </p>
 
-          <div class="text-center">
-            <%= button_to t("thanks.new.submit"),
-                  thanks_path,
-                  method: :post,
-                  class: "px-10 py-4 rounded-full bg-pink-500 text-white font-bold text-lg hover:bg-pink-600 transition" %>
-          </div>
+          <%= form_with model: @thanks, url: thanks_path, local: true do |f| %>
+
+            <div class="mb-10">
+              <p class="font-bold mb-4 text-center">
+                どんなことへのありがとう？
+              </p>
+
+              <!-- 未選択用ダミー -->
+              <%= f.radio_button :tag_id, nil, checked: true, class: "hidden" %>
+
+              <div class="flex flex-wrap gap-3 justify-center">
+                <% @tags.each do |tag| %>
+                  <label class="cursor-pointer">
+                    <%= f.radio_button :tag_id, tag.id, class: "hidden peer" %>
+                    <span
+                      class="
+                        px-4 py-2 rounded-full border
+                        transition-all duration-200
+                        hover:bg-pink-50 hover:border-pink-400 hover:shadow-md hover:scale-105
+                        active:scale-95
+                        peer-checked:bg-pink-500
+                        peer-checked:text-white
+                        peer-checked:border-pink-500
+                      ">
+                      <%= tag.name %>
+                    </span>
+                  </label>
+                <% end %>
+              </div>
+            </div>
+
+            <div class="text-center">
+              <%= f.submit t("thanks.new.submit"),
+                    class: "px-10 py-4 rounded-full bg-pink-500 text-white font-bold text-lg hover:bg-pink-600 transition" %>
+            </div>
+
+          <% end %>
         </section>
 
       </main>
     </div>
   </div>
 <% end %>
-

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -57,3 +57,4 @@ ja:
       submit: "🌸 ありがとうを贈る 🌸"
     create:
       success: "ありがとうを贈りました 💐"
+      failure: "タグを選択してください"

--- a/db/migrate/20260123035912_create_tags.rb
+++ b/db/migrate/20260123035912_create_tags.rb
@@ -1,0 +1,9 @@
+class CreateTags < ActiveRecord::Migration[8.1]
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260123041353_add_tag_to_thanks.rb
+++ b/db/migrate/20260123041353_add_tag_to_thanks.rb
@@ -1,0 +1,5 @@
+class AddTagToThanks < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :thanks, :tag, foreign_key: true
+  end
+end

--- a/db/migrate/20260123043201_add_not_null_to_thanks_tag_id.rb
+++ b/db/migrate/20260123043201_add_not_null_to_thanks_tag_id.rb
@@ -1,0 +1,5 @@
+class AddNotNullToThanksTagId < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :thanks, :tag_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_22_052043) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_23_043201) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -53,13 +53,21 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_22_052043) do
     t.index ["user_id"], name: "index_moods_on_user_id"
   end
 
+  create_table "tags", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "thanks", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.bigint "receiver_id", null: false
     t.bigint "sender_id", null: false
+    t.bigint "tag_id", null: false
     t.datetime "updated_at", null: false
     t.index ["receiver_id"], name: "index_thanks_on_receiver_id"
     t.index ["sender_id"], name: "index_thanks_on_sender_id"
+    t.index ["tag_id"], name: "index_thanks_on_tag_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -80,6 +88,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_22_052043) do
   add_foreign_key "invitations", "couples"
   add_foreign_key "invitations", "users", column: "inviter_id"
   add_foreign_key "moods", "users"
+  add_foreign_key "thanks", "tags"
   add_foreign_key "thanks", "users", column: "receiver_id"
   add_foreign_key "thanks", "users", column: "sender_id"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,14 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+
+Tag.find_or_create_by!(name: "掃除🧹")
+Tag.find_or_create_by!(name: "洗濯🧺")
+Tag.find_or_create_by!(name: "ご飯🍚")
+Tag.find_or_create_by!(name: "洗い物🍴")
+Tag.find_or_create_by!(name: "ゴミ出し🗑️")
+Tag.find_or_create_by!(name: "気遣い😌")
+Tag.find_or_create_by!(name: "助けてくれた🙏")
+Tag.find_or_create_by!(name: "一緒にいて楽しかった🥰")
+Tag.find_or_create_by!(name: "サプライズ🎁")
+Tag.find_or_create_by!(name: "その他🫡")

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
ありがとうにタグを紐づけるための最小構成を実装しました。

## 実装内容
- tags テーブルを追加
- デフォルトタグを seed で登録
- thanks と tag を 1対1 で関連付け
- ありがとう送信時にタグを1つ選択可能に

## 画面
- ありがとう送信ページにタグ選択UIを追加

## 補足
- タグの追加・非表示・複数選択は MVP 後に実装予定
- UI / DB ともに拡張しやすい構成を意識しています