### PR TITLE
今週のありがとう件数表示と週次集計グラフを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ https://www.figma.com/design/fTG4X9fg7jQolInUe7zryh/project?node-id=0-1&p=f&t=d0
 ---
 
 ## ER図
-[![Image from Gyazo](https://i.gyazo.com/b68124d335862332db67c9bb2f2ee7d8.png)](https://gyazo.com/b68124d335862332db67c9bb2f2ee7d8)
+[![Image from Gyazo](https://i.gyazo.com/8a2aa74ec307816fea7f86e91145cc79.png)](https://gyazo.com/8a2aa74ec307816fea7f86e91145cc79)
 
 ## まとめ
 Futari Logは、  

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -18,5 +18,7 @@ class HomeController < ApplicationController
 
     @weekly_average = (@weekly_scores.sum / 7.0).round
     @weekly_level = Mood.level_from_average(@weekly_average)
+    @weekly_received_thanks_count =
+      Thank.this_week.where(receiver: current_user).count
   end
 end

--- a/app/controllers/thanks_controller.rb
+++ b/app/controllers/thanks_controller.rb
@@ -3,6 +3,30 @@ class ThanksController < ApplicationController
 
   def index
     @received_thanks = Thank.where(receiver: current_user).includes(:tag, :sender).order(created_at: :desc)
+    # 今週贈ったありがとう
+    @weekly_sent_thanks_count = Thank.this_week.where(sender: current_user).count
+    # 過去4週間（月曜始まり）
+    start_date = 4.weeks.ago.beginning_of_week
+    end_date   = Time.zone.now.end_of_week
+
+    raw_data = Thank.where(receiver: current_user, sender: current_user.partner, created_at: start_date..end_date)
+           .group(Arel.sql("DATE_TRUNC('week', created_at)"))
+           .order(Arel.sql("DATE_TRUNC('week', created_at)"))
+           .count
+    # 表示用に整形（空週も0で埋める）
+    @weekly_received_thanks = []
+
+    4.times do |i|
+      week_start = (3 - i).weeks.ago.beginning_of_week
+      week_end   = week_start.end_of_week
+
+      count = raw_data[week_start.beginning_of_day] || 0
+
+      @weekly_received_thanks << {
+        label: "#{week_start.strftime('%-m/%-d')}〜#{week_end.strftime('%-m/%-d')}",
+        count: count
+      }
+    end
   end
 
   def new

--- a/app/models/thank.rb
+++ b/app/models/thank.rb
@@ -9,6 +9,10 @@ class Thank < ApplicationRecord
   validate :sender_and_receiver_are_different
   validate :same_couple_only
 
+  scope :this_week, -> {
+    where(created_at: Time.zone.now.beginning_of_week..Time.zone.now.end_of_week)
+  }
+
   private
 
   def sender_and_receiver_are_different

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -81,7 +81,7 @@
             <h3 class="font-bold mb-6 text-lg">今週もらったありがとう</h3>
             <div class="flex items-center gap-8">
               <span class="text-[56px] md:text-[72px]">💌</span>
-              <span class="text-[56px] md:text-[72px] font-bold">3件</span>
+              <span class="text-[56px] md:text-[72px] font-bold"><%= @weekly_received_thanks_count %>件</span>
             </div>
           </div>
         </div>

--- a/app/views/thanks/index.html.erb
+++ b/app/views/thanks/index.html.erb
@@ -62,19 +62,14 @@
         </section>
 
         <h3 class="font-bold mb-6 text-lg">
-          ありがとう集計
+          ありがとう集計 （※グラフが表示されていない場合は一度画面を更新してください）
         </h3>
 
         <!-- ===== 下段：グラフ＆件数 ===== -->
         <div class="grid grid-cols-1 md:grid-cols-2 gap-10">
 
           <div class="bg-white rounded-3xl shadow-sm p-10">
-            <h3 class="font-bold mb-6 text-lg">
-              週別受け取ったありがとうグラフ
-            </h3>
-            <p class="text-gray-400 text-sm">
-              ※ グラフは後で実装
-            </p>
+            <canvas id="weeklyThanksChart"></canvas>
           </div>
 
           <div class="bg-white rounded-3xl shadow-sm p-10">
@@ -83,11 +78,57 @@
             </h3>
             <div class="flex items-center gap-6">
               <span class="text-[56px] md:text-[72px]">💌</span>
-              <span class="text-[56px] md:text-[72px] font-bold">3件</span>
+              <span class="text-[56px] md:text-[72px] font-bold"><%= @weekly_sent_thanks_count %>件</span>
             </div>
           </div>
 
         </div>
+        <!-- Chart.js CDN -->
+        <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+
+        <script>
+          const drawWeeklyThanksChart = () => {
+            const ctx = document.getElementById('weeklyThanksChart');
+            if (!ctx) return;
+
+            const labels = <%= raw(
+              @weekly_received_thanks.map { |w| w[:label] }.to_json
+            ) %>;
+
+            const data = <%= raw(
+              @weekly_received_thanks.map { |w| w[:count] }.to_json
+            ) %>;
+
+            new Chart(ctx, {
+              type: 'bar',
+              data: {
+                labels: labels,
+                datasets: [{
+                  label: 'もらったありがとう',
+                  data: data,
+                  borderWidth: 1
+                }]
+              },
+              options: {
+                responsive: true,
+                scales: {
+                  y: {
+                    beginAtZero: true,
+                    ticks: {
+                      stepSize: 5   // ★ 5刻み
+                    }
+                  }
+                }
+              }
+            });
+          };
+
+          // 初回ロード
+          document.addEventListener("DOMContentLoaded", drawWeeklyThanksChart);
+
+          // Turbo遷移対応（重要）
+          document.addEventListener("turbo:load", drawWeeklyThanksChart);
+        </script>
       </main>
     </div>
   </div>


### PR DESCRIPTION
## 概要
今週のありがとう件数表示と、週次集計グラフを実装しました。

## 実装内容
- トップページに「今週もらったありがとう」の件数を表示
- ありがとう記録ページに「今週贈ったありがとう」の件数を表示
- もらったありがとうの週別件数を棒グラフで可視化（過去5週分）

## 技術的ポイント
- 月曜始まりの週単位集計
- ActiveRecord の group + count を使用
- Chart.js を CDN で利用（JS ビルド不要）

## 確認方法
1. ログイン後トップページで件数が表示されること
2. ありがとう記録ページで今週の送信数が表示されること
3. 週別グラフが正しく描画されること