### PR TITLE
デフォルトタグをモデル側で自動生成する

### DIFF
--- a/app/controllers/thanks_controller.rb
+++ b/app/controllers/thanks_controller.rb
@@ -30,6 +30,7 @@ class ThanksController < ApplicationController
   end
 
   def new
+    Tag.ensure_defaults!
     @thanks = Thank.new
     @tags = Tag.all
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,5 +1,25 @@
 class Tag < ApplicationRecord
   has_many :thanks, dependent: :restrict_with_exception
 
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
+
+  DEFAULT_TAGS = [
+    "掃除🧹",
+    "洗濯🧺",
+    "ご飯🍚",
+    "洗い物🍴",
+    "ゴミ出し🗑️",
+    "気遣い😌",
+    "助けてくれた🙏",
+    "一緒にいて楽しかった🥰",
+    "サプライズ🎁",
+    "その他🫡"
+  ].freeze
+
+  # デフォルトタグが存在しなければ作成する
+  def self.ensure_defaults!
+    DEFAULT_TAGS.each do |name|
+      find_or_create_by!(name: name)
+    end
+  end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,13 +8,4 @@
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
 
-Tag.find_or_create_by!(name: "掃除🧹")
-Tag.find_or_create_by!(name: "洗濯🧺")
-Tag.find_or_create_by!(name: "ご飯🍚")
-Tag.find_or_create_by!(name: "洗い物🍴")
-Tag.find_or_create_by!(name: "ゴミ出し🗑️")
-Tag.find_or_create_by!(name: "気遣い😌")
-Tag.find_or_create_by!(name: "助けてくれた🙏")
-Tag.find_or_create_by!(name: "一緒にいて楽しかった🥰")
-Tag.find_or_create_by!(name: "サプライズ🎁")
-Tag.find_or_create_by!(name: "その他🫡")
+


### PR DESCRIPTION
## 概要
ありがとう投稿時に使用するデフォルトタグを、
seeds.rb ではなく Tag モデル側で自動生成するように変更しました。

## 変更内容
- Tag モデルにデフォルトタグ定義と生成メソッドを追加
- thanks/new アクションで初期タグを保証するよう修正
- 本番環境（Render 無料プラン）でもタグが確実に表示されるよう対応

## 背景・目的
Render 無料プランでは shell / seed 実行ができないため、
アプリ利用時にタグが存在しない問題が発生していました。
モデル側で初期データを保証することで、
環境に依存せず安定して動作する構成にしています。

## 今後の拡張予定
- user_hidden_tags テーブルを追加し、ユーザーごとのタグ非表示機能を実装予定
- tags に visible カラムや created_by_user_id を追加し、
  システムタグ・ユーザー作成タグの管理を行う想定です

## 動作確認
- 開発環境で tags テーブルが空でも画面表示時に自動生成されることを確認