### PR TITLE
ユーザーがカスタムタグを作成できる機能を追加

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,0 +1,24 @@
+class TagsController < ApplicationController
+  before_action :authenticate_user!
+
+  def new
+    @tag = Tag.new
+  end
+
+  def create
+    @tag = Tag.new(tag_params)
+    @tag.created_by_user = current_user
+
+    if @tag.save
+      redirect_to new_thank_path, notice: "タグを追加しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def tag_params
+    params.require(:tag).permit(:name)
+  end
+end

--- a/app/controllers/thanks_controller.rb
+++ b/app/controllers/thanks_controller.rb
@@ -32,14 +32,14 @@ class ThanksController < ApplicationController
   def new
     Tag.ensure_defaults!
     @thanks = Thank.new
-    @tags = Tag.all
+    @tags = Tag.for_user(current_user)
   end
 
   def create
     @thanks = Thank.new(thank_params)
     @thanks.sender = current_user
     @thanks.receiver = partner_user
-    @tags = Tag.all
+    @tags = Tag.for_user(current_user)
 
     if @thanks.save
       redirect_to thanks_path, notice: t("thanks.create.success")

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -1,0 +1,2 @@
+module TagsHelper
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,7 +1,9 @@
 class Tag < ApplicationRecord
   has_many :thanks, dependent: :restrict_with_exception
+  belongs_to :created_by_user, class_name: "User", optional: true
 
   validates :name, presence: true, uniqueness: true
+  validates :name, uniqueness: { scope: :created_by_user_id }
 
   DEFAULT_TAGS = [
     "掃除🧹",
@@ -21,5 +23,10 @@ class Tag < ApplicationRecord
     DEFAULT_TAGS.each do |name|
       find_or_create_by!(name: name)
     end
+  end
+
+  # 表示用（デフォルト + 自分のタグ）
+  def self.for_user(user)
+    where(created_by_user_id: [nil, user.id])
   end
 end

--- a/app/views/tags/create.html.erb
+++ b/app/views/tags/create.html.erb
@@ -1,0 +1,2 @@
+<h1>Tags#create</h1>
+<p>Find me in app/views/tags/create.html.erb</p>

--- a/app/views/tags/new.html.erb
+++ b/app/views/tags/new.html.erb
@@ -1,0 +1,35 @@
+<% if user_signed_in? %>
+  <div class="bg-[#e9f7f7] min-h-screen flex overflow-hidden">
+    <%= render "shared/sidebar_user" %>
+
+    <div class="flex-1">
+      <main class="px-4 md:px-10 py-10">
+
+        <section class="max-w-xl mx-auto bg-white rounded-3xl shadow-sm px-6 py-10">
+          <h1 class="text-2xl font-bold text-center mb-6">
+            タグを追加
+          </h1>
+
+          <p class="text-center text-gray-600 mb-8">
+            自分専用のタグを作成できます
+          </p>
+
+          <%= form_with model: @tag, local: true do |f| %>
+            <div class="mb-6">
+              <%= f.label :name, "タグ名", class: "block font-bold mb-2" %>
+              <%= f.text_field :name,
+                    class: "w-full border rounded-lg px-4 py-2",
+                    placeholder: "例：仕事を手伝ってくれた💻" %>
+            </div>
+
+            <div class="text-center">
+              <%= f.submit "追加する",
+                    class: "px-8 py-3 rounded-full bg-pink-500 text-white font-bold hover:bg-pink-600" %>
+            </div>
+          <% end %>
+        </section>
+
+      </main>
+    </div>
+  </div>
+<% end %>

--- a/app/views/thanks/new.html.erb
+++ b/app/views/thanks/new.html.erb
@@ -52,6 +52,11 @@
                   </label>
                 <% end %>
               </div>
+              <div class="text-center mt-6">
+                <%= link_to "＋ タグを追加する",
+                      new_tag_path,
+                      class: "text-sm text-gray-500 hover:text-pink-500 underline" %>
+              </div>
             </div>
 
             <div class="text-center">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get "tags/new"
+  get "tags/create"
   get "moods/create"
   root "home#index"
   devise_for :users
@@ -14,6 +16,7 @@ Rails.application.routes.draw do
   resources :invitations, only: [ :new, :create ]
   resources :moods, only: [ :create, :index ]
   resources :thanks, only: [ :new, :create, :index ]
+  resources :tags, only: %i[new create]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20260130075519_add_created_by_user_id_to_tags.rb
+++ b/db/migrate/20260130075519_add_created_by_user_id_to_tags.rb
@@ -1,0 +1,6 @@
+class AddCreatedByUserIdToTags < ActiveRecord::Migration[8.1]
+  def change
+    add_column :tags, :created_by_user_id, :bigint
+    add_index  :tags, :created_by_user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_23_043201) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_30_075519) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -55,8 +55,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_23_043201) do
 
   create_table "tags", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.bigint "created_by_user_id"
     t.string "name", null: false
     t.datetime "updated_at", null: false
+    t.index ["created_by_user_id"], name: "index_tags_on_created_by_user_id"
   end
 
   create_table "thanks", force: :cascade do |t|

--- a/test/controllers/tags_controller_test.rb
+++ b/test/controllers/tags_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class TagsControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get tags_new_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get tags_create_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要
ユーザーが自分専用のタグを作成できる機能を追加しました。

## 実装内容
- tags に created_by_user_id を追加
- デフォルトタグとユーザータグを分離管理
- タグ作成画面の追加（サイドバー・レスポンシブ対応）
- ありがとう投稿画面からタグ追加への導線を追加

## 設計意図
- デフォルトタグ：created_by_user_id = NULL
- ユーザータグ：created_by_user_id = user.id
- 将来的なタグ非表示機能（user_hidden_tags）に対応しやすい構成

## 動作確認
- 自分で作成したタグが投稿画面に表示されること
- 他ユーザーのタグは表示されないこと