### PR TITLE
タグをユーザー単位で非表示・再表示できるようにする

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -2,7 +2,9 @@ class TagsController < ApplicationController
   before_action :authenticate_user!
 
   def new
+    Tag.ensure_defaults!
     @tag = Tag.new
+    @tags = Tag.for_user(current_user)
   end
 
   def create
@@ -14,6 +16,19 @@ class TagsController < ApplicationController
     else
       render :new, status: :unprocessable_entity
     end
+  end
+
+  def toggle_visibility
+    tag = Tag.for_user(current_user).find(params[:id])
+
+    hidden = current_user.user_hidden_tags.find_by(tag:)
+    if hidden
+      hidden.destroy
+    else
+      current_user.user_hidden_tags.create!(tag:)
+    end
+
+    redirect_to new_tag_path
   end
 
   private

--- a/app/controllers/thanks_controller.rb
+++ b/app/controllers/thanks_controller.rb
@@ -32,14 +32,14 @@ class ThanksController < ApplicationController
   def new
     Tag.ensure_defaults!
     @thanks = Thank.new
-    @tags = Tag.for_user(current_user)
+    @tags = Tag.visible_for(current_user)
   end
 
   def create
     @thanks = Thank.new(thank_params)
     @thanks.sender = current_user
     @thanks.receiver = partner_user
-    @tags = Tag.for_user(current_user)
+    @tags = Tag.visible_for(current_user)
 
     if @thanks.save
       redirect_to thanks_path, notice: t("thanks.create.success")

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,9 +1,21 @@
 class Tag < ApplicationRecord
   has_many :thanks, dependent: :restrict_with_exception
+  has_many :user_hidden_tags, dependent: :destroy
   belongs_to :created_by_user, class_name: "User", optional: true
 
   validates :name, presence: true, uniqueness: true
   validates :name, uniqueness: { scope: :created_by_user_id }
+
+  # ありがとう作成画面用（非表示タグ除外）
+  scope :visible_for, ->(user) {
+    where(created_by_user_id: [ nil, user.id ])
+      .where.not(id: user.user_hidden_tags.select(:tag_id))
+  }
+
+  # タグ管理画面用（表示・非表示含めて全部）
+  scope :for_user, ->(user) {
+    where(created_by_user_id: [ nil, user.id ])
+  }
 
   DEFAULT_TAGS = [
     "掃除🧹",
@@ -23,10 +35,5 @@ class Tag < ApplicationRecord
     DEFAULT_TAGS.each do |name|
       find_or_create_by!(name: name)
     end
-  end
-
-  # 表示用（デフォルト + 自分のタグ）
-  def self.for_user(user)
-    where(created_by_user_id: [nil, user.id])
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ApplicationRecord
   has_many :couples, through: :couple_users
   has_many :invitations, foreign_key: :inviter_id, dependent: :destroy
   has_many :moods, dependent: :destroy
+  has_many :user_hidden_tags, dependent: :destroy
 
   def partner
     return nil if couples.blank?

--- a/app/models/user_hidden_tag.rb
+++ b/app/models/user_hidden_tag.rb
@@ -1,0 +1,6 @@
+class UserHiddenTag < ApplicationRecord
+  belongs_to :user
+  belongs_to :tag
+
+  validates :user_id, uniqueness: { scope: :tag_id }
+end

--- a/app/views/tags/new.html.erb
+++ b/app/views/tags/new.html.erb
@@ -2,21 +2,26 @@
   <div class="bg-[#e9f7f7] min-h-screen flex overflow-hidden">
     <%= render "shared/sidebar_user" %>
 
-    <div class="flex-1">
-      <main class="px-4 md:px-10 py-10">
+    <div id="content-wrapper" class="flex-1 transition-transform duration-300">
+      <main class="px-4 md:px-10 py-10 max-w-2xl mx-auto">
 
-        <section class="max-w-xl mx-auto bg-white rounded-3xl shadow-sm px-6 py-10">
-          <h1 class="text-2xl font-bold text-center mb-6">
+        <!-- ☰（スマホ） -->
+        <div class="md:hidden mb-6">
+          <button id="sidebar-toggle"
+            class="flex items-center gap-2 border border-gray-300 rounded-lg px-3 py-2 bg-white shadow-sm text-gray-700">
+            <span class="text-xl">☰</span>
+            <span class="text-sm">メニュー</span>
+          </button>
+        </div>
+
+        <!-- 新規作成 -->
+        <section class="bg-white rounded-3xl shadow-sm px-6 py-8 mb-10">
+          <h1 class="text-xl font-bold text-center mb-6">
             タグを追加
           </h1>
 
-          <p class="text-center text-gray-600 mb-8">
-            自分専用のタグを作成できます
-          </p>
-
           <%= form_with model: @tag, local: true do |f| %>
             <div class="mb-6">
-              <%= f.label :name, "タグ名", class: "block font-bold mb-2" %>
               <%= f.text_field :name,
                     class: "w-full border rounded-lg px-4 py-2",
                     placeholder: "例：仕事を手伝ってくれた💻" %>
@@ -27,6 +32,32 @@
                     class: "px-8 py-3 rounded-full bg-pink-500 text-white font-bold hover:bg-pink-600" %>
             </div>
           <% end %>
+        </section>
+
+        <!-- 表示管理 -->
+        <section class="bg-white rounded-3xl shadow-sm px-6 py-8">
+          <h2 class="text-lg font-bold mb-6 text-center">
+            タグの表示設定
+          </h2>
+
+          <ul class="space-y-4">
+            <% @tags.each do |tag| %>
+              <% hidden = current_user.user_hidden_tags.exists?(tag:) %>
+
+              <li class="flex justify-between items-center">
+                <span class="<%= 'line-through text-gray-400' if hidden %>">
+                  <%= tag.name %>
+                </span>
+
+                <%= button_to(
+                      hidden ? "表示する" : "非表示",
+                      toggle_visibility_tag_path(tag),
+                      method: :post,
+                      class: "px-4 py-1 rounded-full border text-sm"
+                    ) %>
+              </li>
+            <% end %>
+          </ul>
         </section>
 
       </main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,11 @@ Rails.application.routes.draw do
   resources :invitations, only: [ :new, :create ]
   resources :moods, only: [ :create, :index ]
   resources :thanks, only: [ :new, :create, :index ]
-  resources :tags, only: %i[new create]
+  resources :tags, only: %i[new create] do
+    member do
+      post :toggle_visibility
+    end
+  end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20260130093610_create_user_hidden_tags.rb
+++ b/db/migrate/20260130093610_create_user_hidden_tags.rb
@@ -1,0 +1,10 @@
+class CreateUserHiddenTags < ActiveRecord::Migration[8.1]
+  def change
+    create_table :user_hidden_tags do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_30_075519) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_30_093610) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -72,6 +72,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_30_075519) do
     t.index ["tag_id"], name: "index_thanks_on_tag_id"
   end
 
+  create_table "user_hidden_tags", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["tag_id"], name: "index_user_hidden_tags_on_tag_id"
+    t.index ["user_id"], name: "index_user_hidden_tags_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email", default: "", null: false
@@ -93,4 +102,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_30_075519) do
   add_foreign_key "thanks", "tags"
   add_foreign_key "thanks", "users", column: "receiver_id"
   add_foreign_key "thanks", "users", column: "sender_id"
+  add_foreign_key "user_hidden_tags", "tags"
+  add_foreign_key "user_hidden_tags", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,5 +7,3 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
-
-

--- a/test/fixtures/user_hidden_tags.yml
+++ b/test/fixtures/user_hidden_tags.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  tag: one
+
+two:
+  user: two
+  tag: two

--- a/test/models/user_hidden_tag_test.rb
+++ b/test/models/user_hidden_tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserHiddenTagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
ユーザーごとにタグの表示・非表示を管理できる機能を追加しました。

## 実装内容
- user_hidden_tags テーブルを追加
- デフォルトタグ／カスタムタグ両方に対応
- タグ管理画面で表示切替が可能
- Thanks 作成画面では非表示タグを除外

## 確認方法
1. タグ管理画面でタグを非表示
2. ありがとう作成画面で非表示タグが出ないこと
3. 再表示すると即反映されること

## 補足
タグの表示状態は user_hidden_tags の有無で管理しています。