### PR TITLE
本番環境で週次ありがとうグラフが表示されない不具合を修正

### DIFF
--- a/app/controllers/thanks_controller.rb
+++ b/app/controllers/thanks_controller.rb
@@ -2,25 +2,42 @@ class ThanksController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @received_thanks = Thank.where(receiver: current_user).includes(:tag, :sender).order(created_at: :desc)
+    @received_thanks = Thank
+      .where(receiver: current_user)
+      .includes(:tag, :sender)
+      .order(created_at: :desc)
+
     # 今週贈ったありがとう
-    @weekly_sent_thanks_count = Thank.this_week.where(sender: current_user).count
+    @weekly_sent_thanks_count =
+      Thank.this_week.where(sender: current_user).count
+
     # 過去4週間（月曜始まり）
     start_date = 4.weeks.ago.beginning_of_week
     end_date   = Time.zone.now.end_of_week
 
-    raw_data = Thank.where(receiver: current_user, sender: current_user.partner, created_at: start_date..end_date)
-           .group(Arel.sql("DATE_TRUNC('week', created_at)"))
-           .order(Arel.sql("DATE_TRUNC('week', created_at)"))
-           .count
+    # DB側は UTC のまま週単位で集計
+    raw_data = Thank
+      .where(
+        receiver: current_user,
+        sender: current_user.partner,
+        created_at: start_date..end_date
+      )
+      .group(Arel.sql("DATE_TRUNC('week', created_at)"))
+      .count
+
+    # key を Date に正規化する
+    normalized_data = raw_data.transform_keys do |time|
+      time.to_date
+    end
+
     # 表示用に整形（空週も0で埋める）
     @weekly_received_thanks = []
 
     4.times do |i|
-      week_start = (3 - i).weeks.ago.beginning_of_week
-      week_end   = week_start.end_of_week
+      week_start = (3 - i).weeks.ago.beginning_of_week.to_date
+      week_end   = week_start.end_of_week.to_date
 
-      count = raw_data[week_start.beginning_of_day] || 0
+      count = normalized_data[week_start] || 0
 
       @weekly_received_thanks << {
         label: "#{week_start.strftime('%-m/%-d')}〜#{week_end.strftime('%-m/%-d')}",
@@ -28,6 +45,7 @@ class ThanksController < ApplicationController
       }
     end
   end
+
 
   def new
     Tag.ensure_defaults!


### PR DESCRIPTION
## 概要
本番環境で「もらったありがとう」の週次グラフが表示されない不具合を修正しました。

開発環境では正常に表示されていましたが、
本番環境ではグラフがすべて 0 件として描画される問題が発生していました。

---

## 原因
PostgreSQL での週単位集計（`DATE_TRUNC('week', created_at)`）は UTC 基準で行われる一方、
Rails 側では JST 基準で週の開始日を計算しており、
集計結果のキーが一致していませんでした。

そのため、実データが存在していても
表示用ロジックで 0 件として扱われていました。

---

## 対応内容
- DB 集計結果のキーを `Date` に正規化
- Ruby 側で生成する週のキーも `Date` に統一
- 表示用のラベル・Chart.js・ビューの変更はなし

---

## 影響範囲
- ThanksController#index の週次集計ロジックのみ
- 既存の画面表示・開発環境の挙動には影響なし

---

## 動作確認
- 開発環境で週次グラフがこれまで通り表示されることを確認
- 本番環境で、ありがとう送受信後にグラフへ正しく反映されることを確認

---

## 補足
この修正により、タイムゾーン差異がある環境（Render / PostgreSQL）でも
週次集計が安定して動作するようになります。