### PR TITLE
設定画面とカップル設定画面を作成しパートナー表示名変更機能を追加

### DIFF
--- a/app/controllers/couple_settings_controller.rb
+++ b/app/controllers/couple_settings_controller.rb
@@ -1,0 +1,27 @@
+# app/controllers/couple_settings_controller.rb
+class CoupleSettingsController < ApplicationController
+  before_action :authenticate_user!
+
+  def show
+    @couple_user = current_user.couple_users.first
+    @partner = current_user.partner
+  end
+
+  def update
+    @couple_user = current_user.couple_users.first
+    @partner = current_user.partner
+
+    if @couple_user.update(couple_user_params)
+      redirect_to couple_settings_path, notice: "パートナーの表示名を更新しました"
+    else
+      flash.now[:alert] = "更新に失敗しました"
+      render :show, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def couple_user_params
+    params.require(:couple_user).permit(:partner_nickname)
+  end
+end

--- a/app/controllers/moods_controller.rb
+++ b/app/controllers/moods_controller.rb
@@ -2,6 +2,11 @@ class MoodsController < ApplicationController
   before_action :authenticate_user!
 
   def index
+    @partner = current_user.partner
+    @partner_display_name =
+      current_user.couple_users.first&.partner_nickname.presence ||
+      @partner&.nickname
+
     @week_dates = (Date.current - 6.days..Date.current).to_a.reverse
 
     moods = current_user.moods.where(recorded_on: @week_dates).index_by(&:recorded_on)

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,0 +1,4 @@
+class SettingsController < ApplicationController
+  def show
+  end
+end

--- a/app/helpers/couple_settings_helper.rb
+++ b/app/helpers/couple_settings_helper.rb
@@ -1,0 +1,2 @@
+module CoupleSettingsHelper
+end

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -1,0 +1,2 @@
+module SettingsHelper
+end

--- a/app/views/couple_settings/show.html.erb
+++ b/app/views/couple_settings/show.html.erb
@@ -1,0 +1,58 @@
+<% if user_signed_in? %>
+  <div class="bg-[#e9f7f7] min-h-screen flex overflow-hidden">
+    <%= render "shared/sidebar_user" %>
+
+    <div id="content-wrapper" class="flex-1 transition-transform duration-300">
+      <main class="px-4 md:px-10 py-8 max-w-full overflow-x-hidden">
+
+        <!-- ☰（スマホ） -->
+        <div class="md:hidden mb-6">
+          <button id="sidebar-toggle"
+            class="flex items-center gap-2 border border-gray-300 rounded-lg px-3 py-2 bg-white shadow-sm text-gray-700">
+            <span class="text-xl">☰</span>
+            <span class="text-sm">メニュー</span>
+          </button>
+        </div>
+
+        <section class="max-w-xl mx-auto bg-white rounded-3xl shadow-sm px-6 py-10">
+          <h1 class="text-xl font-bold text-center mb-8">
+            カップル設定
+          </h1>
+
+          <% if @partner.present? %>
+            <%= form_with model: @couple_user,
+                  url: couple_settings_path,
+                  method: :patch,
+                  local: true do |f| %>
+
+              <div class="mb-6">
+                <label class="block font-bold mb-2">
+                  パートナーの表示名（自分だけに表示されます）
+                </label>
+
+                <%= f.text_field :partner_nickname,
+                      class: "w-full border rounded-lg px-4 py-2",
+                      placeholder: @partner.nickname %>
+              </div>
+
+              <div class="text-center">
+                <%= f.submit "更新する",
+                      class: "px-8 py-3 rounded-full bg-pink-500 text-white font-bold hover:bg-pink-600" %>
+              </div>
+            <% end %>
+
+            <!-- 次 issue 用 -->
+            <div class="mt-10 border-t pt-6 text-center text-gray-400">
+              カップル解除（準備中）
+            </div>
+          <% else %>
+            <p class="text-center text-gray-500">
+              まだカップルが設定されていません
+            </p>
+          <% end %>
+        </section>
+
+      </main>
+    </div>
+  </div>
+<% end %>

--- a/app/views/couple_settings/update.html.erb
+++ b/app/views/couple_settings/update.html.erb
@@ -1,0 +1,2 @@
+<h1>CoupleSettings#update</h1>
+<p>Find me in app/views/couple_settings/update.html.erb</p>

--- a/app/views/moods/index.html.erb
+++ b/app/views/moods/index.html.erb
@@ -38,7 +38,7 @@
 
         <% if current_user.partner.present? %>
           <p class="text-lg font-bold mb-6">
-            最近の<%= current_user.partner.nickname %>さんの様子
+            最近の<%= @partner_display_name %>さんの様子
           </p>
           
           <div class="grid grid-cols-1 md:grid-cols-2 gap-10">

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -1,0 +1,48 @@
+<% if user_signed_in? %>
+  <div class="bg-[#e9f7f7] min-h-screen flex overflow-hidden">
+    <%= render "shared/sidebar_user" %>
+
+    <div id="content-wrapper" class="flex-1 transition-transform duration-300">
+      <main class="px-4 md:px-10 py-8 max-w-full overflow-x-hidden">
+
+        <!-- ☰（スマホ） -->
+        <div class="md:hidden mb-6">
+          <button id="sidebar-toggle"
+            class="flex items-center gap-2 border border-gray-300 rounded-lg px-3 py-2 bg-white shadow-sm text-gray-700">
+            <span class="text-xl">☰</span>
+            <span class="text-sm">メニュー</span>
+          </button>
+        </div>
+
+        <h1 class="text-2xl font-bold text-center mb-10">
+          設定
+        </h1>
+
+        <div class="max-w-md mx-auto space-y-6">
+          <div class="block text-center border rounded-full py-4 bg-gray-100 text-gray-400">
+            アカウント設定（準備中）
+          </div>
+
+          <%= link_to "カップル設定", couple_settings_path,
+                class: "block text-center border rounded-full py-4 bg-white shadow hover:bg-gray-50" %>
+
+          <%= link_to "ありがとうタグ管理", new_tag_path,
+                class: "block text-center border rounded-full py-4 bg-white shadow hover:bg-gray-50" %>
+
+          <div class="block text-center border rounded-full py-4 bg-gray-100 text-gray-400">
+            通知設定（準備中）
+          </div>
+
+          <div class="block text-center border rounded-full py-4 bg-gray-100 text-gray-400">
+            利用規約（準備中）
+          </div>
+
+          <div class="block text-center border rounded-full py-4 bg-gray-100 text-gray-400">
+            プライバシーポリシー（準備中）
+          </div>
+        </div>
+
+      </main>
+    </div>
+  </div>
+<% end %>

--- a/app/views/shared/_sidebar_user.html.erb
+++ b/app/views/shared/_sidebar_user.html.erb
@@ -9,7 +9,7 @@
 
     <%= link_to "ごきげん記録", moods_path, class: "px-6 py-4 hover:bg-cyan-50" %>
     <%= link_to "ありがとう記録", thanks_path, class: "px-6 py-4 hover:bg-cyan-50" %>
-    <%= link_to "設定", "#", class: "px-6 py-4 hover:bg-cyan-50" %>
+    <%= link_to "設定", settings_path, class: "px-6 py-4 hover:bg-cyan-50" %>
   </nav>
 </aside>
 
@@ -30,6 +30,6 @@
 
     <%= link_to "ごきげん記録", moods_path, class: "px-6 py-4 hover:bg-cyan-50" %>
     <%= link_to "ありがとう記録", thanks_path, class: "px-6 py-4 hover:bg-cyan-50" %>
-    <%= link_to "設定", "#", class: "px-6 py-4 hover:bg-cyan-50" %>
+    <%= link_to "設定", settings_path, class: "px-6 py-4 hover:bg-cyan-50" %>
   </nav>
 </aside>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  get "couple_settings/show"
+  get "couple_settings/update"
+  get "settings/show"
   get "tags/new"
   get "tags/create"
   get "moods/create"
@@ -21,6 +24,8 @@ Rails.application.routes.draw do
       post :toggle_visibility
     end
   end
+  resource :settings, only: [ :show ]
+  resource :couple_settings, only: [ :show, :update ]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/test/controllers/couple_settings_controller_test.rb
+++ b/test/controllers/couple_settings_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class CoupleSettingsControllerTest < ActionDispatch::IntegrationTest
+  test "should get show" do
+    get couple_settings_show_url
+    assert_response :success
+  end
+
+  test "should get update" do
+    get couple_settings_update_url
+    assert_response :success
+  end
+end

--- a/test/controllers/settings_controller_test.rb
+++ b/test/controllers/settings_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class SettingsControllerTest < ActionDispatch::IntegrationTest
+  test "should get show" do
+    get settings_show_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要
設定画面およびカップル設定画面を新規作成しました。

## 変更内容
- 設定画面を作成し、各設定項目への導線を追加
- カップル設定画面を作成
- ログインユーザーの画面でのみ、パートナーの表示名を変更できるよう実装
- 次 issue（カップル解除）に備えたUI枠を用意
- 既存ビューと統一感のあるデザインに調整
- スマホ対応・サイドバーメニュー対応

## 確認方法
1. サイドバーの「設定」をクリック
2. 設定画面が表示されること
3. 「カップル設定」からパートナー表示名を変更できること
4. 「ありがとうタグ管理」から既存ページに遷移できること

## 補足
カップル解除機能は次の issue で実装予定です。