### PR TITLE
利用規約・プライバシーポリシーの作成と導線追加

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,0 +1,7 @@
+class StaticPagesController < ApplicationController
+  def terms
+  end
+
+  def privacy
+  end
+end

--- a/app/helpers/static_pages_helper.rb
+++ b/app/helpers/static_pages_helper.rb
@@ -1,0 +1,2 @@
+module StaticPagesHelper
+end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -34,31 +34,44 @@
       </div>
 
       <!-- パスワード確認 -->
-      <div class="mb-8 text-left">
+      <div class="mb-6 text-left">
         <%= f.label :password_confirmation, "パスワード（確認）",
               class: "block text-sm font-medium text-gray-700 mb-1" %>
         <%= f.password_field :password_confirmation,
               class: "w-full rounded-md border border-gray-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-cyan-300" %>
       </div>
 
+      <!-- 利用規約同意 -->
+      <div class="mb-8">
+        <label class="flex items-start text-sm text-gray-700">
+          <%= check_box_tag :accept_terms, "1", false,
+                required: true,
+                class: "mt-1 mr-2" %>
+          <span class="leading-relaxed">
+            <%= link_to "利用規約", terms_path,
+                  target: "_blank",
+                  class: "underline hover:text-gray-800" %> と
+            <%= link_to "プライバシーポリシー", privacy_path,
+                  target: "_blank",
+                  class: "underline hover:text-gray-800" %>
+            に同意します
+          </span>
+        </label>
+      </div>
+
       <!-- 登録ボタン -->
-      <div class="flex justify-end mb-6">
+      <div class="flex justify-center mb-6">
         <%= f.submit "登録",
               class: "px-8 py-2 rounded-md bg-gray-200 border border-gray-500 text-gray-800 hover:bg-gray-300 transition" %>
       </div>
 
     <% end %>
 
-    <!-- 利用規約 / プライバシー -->
-    <div class="text-center text-sm text-gray-600 space-y-3">
-      <div class="flex justify-center gap-6">
-        <span>利用規約 <span class="text-green-500">✅</span></span>
-        <span>プライバシーポリシー <span class="text-green-500">✅</span></span>
-      </div>
-
+    <!-- ログイン導線 -->
+    <div class="text-center text-sm text-gray-600">
       <%= link_to "登録済みの方はこちら",
             new_user_session_path,
-            class: "underline hover:text-gray-800 block mt-2" %>
+            class: "underline hover:text-gray-800" %>
     </div>
 
   </div>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -33,13 +33,11 @@
             通知設定（準備中）
           </div>
 
-          <div class="block text-center border rounded-full py-4 bg-gray-100 text-gray-400">
-            利用規約（準備中）
-          </div>
+          <%= link_to "利用規約", terms_path,
+                class: "block text-center border rounded-full py-4 bg-white shadow hover:bg-gray-50" %>
 
-          <div class="block text-center border rounded-full py-4 bg-gray-100 text-gray-400">
-            プライバシーポリシー（準備中）
-          </div>
+          <%= link_to "プライバシーポリシー", privacy_path,
+                class: "block text-center border rounded-full py-4 bg-white shadow hover:bg-gray-50" %>
         </div>
 
       </main>

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -1,0 +1,46 @@
+<section class="bg-[#e9f7f7] min-h-screen px-4 py-10">
+  <div class="max-w-3xl mx-auto bg-white rounded-2xl shadow px-6 py-10">
+
+    <h1 class="text-2xl font-bold mb-6 text-center">
+      プライバシーポリシー
+    </h1>
+
+    <div class="text-sm text-gray-700 space-y-6 leading-relaxed">
+      <p>
+        本プライバシーポリシーは、Futari Log における
+        個人情報の取り扱いについて定めるものです。
+      </p>
+
+      <h2 class="font-bold">1. 収集する情報</h2>
+      <p>
+        本サービスでは、以下の情報を取得します。
+      </p>
+      <ul class="list-disc ml-6">
+        <li>ニックネーム</li>
+        <li>メールアドレス</li>
+        <li>ごきげん・ありがとうの記録</li>
+      </ul>
+
+      <h2 class="font-bold">2. 利用目的</h2>
+      <p>
+        取得した情報は、本サービスの提供および改善のために使用します。
+      </p>
+
+      <h2 class="font-bold">3. 第三者提供</h2>
+      <p>
+        法令に基づく場合を除き、第三者に提供することはありません。
+      </p>
+
+      <h2 class="font-bold">4. データ削除</h2>
+      <p>
+        利用者がカップル解除または退会した場合、
+        関連データは削除されます。
+      </p>
+
+      <p class="text-right text-xs text-gray-400">
+        制定日：2026年2月
+      </p>
+    </div>
+
+  </div>
+</section>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -1,0 +1,48 @@
+<section class="bg-[#e9f7f7] min-h-screen px-4 py-10">
+  <div class="max-w-3xl mx-auto bg-white rounded-2xl shadow px-6 py-10">
+
+    <h1 class="text-2xl font-bold mb-6 text-center">
+      利用規約
+    </h1>
+
+    <div class="text-sm text-gray-700 space-y-6 leading-relaxed">
+      <p>
+        本利用規約（以下「本規約」）は、Futari Log（以下「本サービス」）の
+        利用条件を定めるものです。
+      </p>
+
+      <h2 class="font-bold">第1条（利用登録）</h2>
+      <p>
+        本サービスの利用を希望する方は、本規約に同意の上、
+        所定の方法により利用登録を行うものとします。
+      </p>
+
+      <h2 class="font-bold">第2条（禁止事項）</h2>
+      <p>
+        利用者は、以下の行為をしてはなりません。
+      </p>
+      <ul class="list-disc ml-6">
+        <li>法令または公序良俗に違反する行為</li>
+        <li>他の利用者に不利益を与える行為</li>
+        <li>本サービスの運営を妨害する行為</li>
+      </ul>
+
+      <h2 class="font-bold">第3条（サービスの停止）</h2>
+      <p>
+        当方は、必要と判断した場合、事前の通知なく本サービスの全部または一部を
+        停止することができます。
+      </p>
+
+      <h2 class="font-bold">第4条（免責事項）</h2>
+      <p>
+        本サービスの利用により生じた損害について、
+        当方は一切の責任を負いません。
+      </p>
+
+      <p class="text-right text-xs text-gray-400">
+        制定日：2026年2月
+      </p>
+    </div>
+
+  </div>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get "static_pages/terms"
+  get "static_pages/privacy"
   get "couple_settings/show"
   get "couple_settings/update"
   get "settings/show"
@@ -12,6 +14,9 @@ Rails.application.routes.draw do
   # 招待コード参加（追加）
   get  "invitations/use", to: "invitations#use_form"
   post "invitations/use", to: "invitations#use"
+  # 利用規約とプライバシーポリシー
+  get "/terms",   to: "static_pages#terms"
+  get "/privacy", to: "static_pages#privacy"
   namespace :couples do
     get "onboarding", to: "onboarding#choice"
   end

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class StaticPagesControllerTest < ActionDispatch::IntegrationTest
+  test "should get terms" do
+    get static_pages_terms_url
+    assert_response :success
+  end
+
+  test "should get privacy" do
+    get static_pages_privacy_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要
利用規約およびプライバシーポリシーを実装し、
新規登録時・ログイン後の設定画面から参照できるようにしました。

## 実装内容
- 利用規約ページの作成（内容含む）
- プライバシーポリシーページの作成（内容含む）
- 新規登録画面に同意チェックボックスを追加
- 設定画面から両ページへの導線を追加
- 既存ユーザーに影響が出ない設計で実装

## 確認方法
- 未ログイン時：新規登録画面から各ページに遷移可能
- チェック未入力では登録不可
- ログイン後：設定画面から各ページに遷移可能