### PR TITLE
パスワードリセット用のメール送信設定を追加

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  default from: ENV.fetch("MAIL_FROM")
   layout "mailer"
 end

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,19 @@
-<p>Welcome <%= @email %>!</p>
+<p><%= @email %> 様</p>
 
-<p>You can confirm your account email through the link below:</p>
+<p>
+  Futari Log へのご登録ありがとうございます。
+</p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p>
+  下記のリンクをクリックして、メールアドレスの確認を完了してください。
+</p>
+
+<p style="margin: 24px 0;">
+  <%= link_to "メールアドレスを確認する",
+        confirmation_url(@resource, confirmation_token: @token),
+        style: "display:inline-block;padding:12px 20px;background:#14b8a6;color:#fff;text-decoration:none;border-radius:6px;" %>
+</p>
+
+<p>
+  今後とも Futari Log をよろしくお願いいたします。
+</p>

--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -1,7 +1,20 @@
-<p>Hello <%= @email %>!</p>
+<p><%= @email %> 様</p>
 
 <% if @resource.try(:unconfirmed_email?) %>
-  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
+  <p>
+    Futari Log に登録されているメールアドレスの変更申請を受け付けました。
+  </p>
+
+  <p>
+    新しいメールアドレス：<br>
+    <strong><%= @resource.unconfirmed_email %></strong>
+  </p>
 <% else %>
-  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
+  <p>
+    Futari Log に登録されているメールアドレスが変更されました。
+  </p>
 <% end %>
+
+<p>
+  もしこの変更に心当たりがない場合は、サポートまでご連絡ください。
+</p>

--- a/app/views/devise/mailer/password_change.html.erb
+++ b/app/views/devise/mailer/password_change.html.erb
@@ -1,3 +1,14 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= @resource.email %> 様</p>
 
-<p>We're contacting you to notify you that your password has been changed.</p>
+<p>
+  Futari Log にご登録のパスワードが変更されました。
+</p>
+
+<p>
+  もしこの変更に心当たりがない場合は、<br>
+  早急にパスワードの再設定を行ってください。
+</p>
+
+<p>
+  今後とも Futari Log をよろしくお願いいたします。
+</p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,29 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= @resource.email %> 様</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p>
+  Futari Log をご利用いただきありがとうございます。
+</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p>
+  パスワード再設定のご依頼を受け付けました。<br>
+  下記のリンクから、新しいパスワードを設定してください。
+</p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p style="margin: 24px 0;">
+  <%= link_to "パスワードを再設定する",
+        edit_password_url(@resource, reset_password_token: @token),
+        style: "display:inline-block;padding:12px 20px;background:#14b8a6;color:#fff;text-decoration:none;border-radius:6px;" %>
+</p>
+
+<p>
+  ※このリンクの有効期限は <strong>6時間</strong> です。
+</p>
+
+<p>
+  もしこのメールに心当たりがない場合は、<br>
+  本メールは破棄してください。パスワードは変更されません。
+</p>
+
+<p>
+  今後とも Futari Log をよろしくお願いいたします。
+</p>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,7 +1,16 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= @resource.email %> 様</p>
 
-<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+<p>
+  複数回のログイン失敗により、<br>
+  あなたのアカウントは一時的にロックされました。
+</p>
 
-<p>Click the link below to unlock your account:</p>
+<p>
+  下記のリンクからロック解除を行ってください。
+</p>
 
-<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>
+<p style="margin: 24px 0;">
+  <%= link_to "アカウントのロックを解除する",
+        unlock_url(@resource, unlock_token: @token),
+        style: "display:inline-block;padding:12px 20px;background:#ef4444;color:#fff;text-decoration:none;border-radius:6px;" %>
+</p>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,21 +53,32 @@ Rails.application.configure do
   config.active_job.queue_adapter = :solid_queue
   config.solid_queue.connects_to = { database: { writing: :queue } }
 
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  # === Action Mailer 設定（Gmail SMTP） ==========================
 
-  # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
+  # メール送信エラーをログに出す（本番では重要）
+  config.action_mailer.raise_delivery_errors = true
 
-  # Specify outgoing SMTP server. Remember to add smtp/* credentials via bin/rails credentials:edit.
-  # config.action_mailer.smtp_settings = {
-  #   user_name: Rails.application.credentials.dig(:smtp, :user_name),
-  #   password: Rails.application.credentials.dig(:smtp, :password),
-  #   address: "smtp.example.com",
-  #   port: 587,
-  #   authentication: :plain
-  # }
+  # 配送方法を SMTP に指定
+  config.action_mailer.delivery_method = :smtp
+
+  # Gmail SMTP 設定（環境変数使用）
+  config.action_mailer.smtp_settings = {
+    address: "smtp.gmail.com",
+    port: 587,
+    domain: "gmail.com",
+    user_name: ENV["GMAIL_USERNAME"],
+    password: ENV["GMAIL_APP_PASSWORD"],
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
+
+  # Devise のメール内リンク用 URL
+  config.action_mailer.default_url_options = {
+    host: "futari-log.onrender.com",
+    protocol: "https"
+  }
+
+  # =============================================================
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
## 概要
Devise のパスワードリセット機能を本番環境で利用できるよう、
SMTP（SendGrid）を用いたメール送信設定を追加しました。

## 変更内容
- ActionMailer の SMTP 設定を追加
- 本番・開発環境での default_url_options 設定
- ApplicationMailer の送信元アドレス設定

## 動作確認
- パスワード再設定メールが送信されること
- メール内リンクからパスワード変更ができること

## 補足
- Devise 標準の mailer/view を利用
- 既存ユーザーへの影響なし