### PR TITLE
Resendを用いたパスワードリセットメール送信を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ gem "stimulus-rails"
 gem "cssbundling-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
+# password reset email
+gem "resend"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.3)
       railties (>= 6.0.0)
+    csv (3.3.5)
     date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
@@ -141,6 +142,10 @@ GEM
       raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    httparty (0.24.2)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     image_processing (1.14.0)
@@ -188,6 +193,8 @@ GEM
     minitest (6.0.1)
       prism (~> 1.5)
     msgpack (1.8.0)
+    multi_xml (0.8.1)
+      bigdecimal (>= 3.1, < 5)
     net-imap (0.6.2)
       date
       net-protocol
@@ -298,6 +305,8 @@ GEM
     regexp_parser (2.11.3)
     reline (0.6.3)
       io-console (~> 0.5)
+    resend (1.0.0)
+      httparty (>= 0.21.0)
     responders (3.2.0)
       actionpack (>= 7.0)
       railties (>= 7.0)
@@ -447,6 +456,7 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails (~> 8.1.1)
+  resend
   rspec-rails
   rubocop-rails-omakase
   selenium-webdriver
@@ -490,6 +500,7 @@ CHECKSUMS
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   cssbundling-rails (1.4.3) sha256=53aecd5a7d24ac9c8fcd92975acd0e830fead4ee4583d3d3d49bb64651946e41
+  csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
   devise (4.9.4) sha256=920042fe5e704c548aa4eb65ebdd65980b83ffae67feb32c697206bfd975a7f8
@@ -511,6 +522,7 @@ CHECKSUMS
   ffi (1.17.3-x86_64-linux-musl) sha256=086b221c3a68320b7564066f46fed23449a44f7a1935f1fe5a245bd89d9aea56
   fugit (1.12.1) sha256=5898f478ede9b415f0804e42b8f3fd53f814bd85eebffceebdbc34e1107aaf68
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
+  httparty (0.24.2) sha256=8fca6a54aa0c4aa4303a0fd33e5e2156175d6a5334f714263b458abd7fda9c38
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   image_processing (1.14.0) sha256=754cc169c9c262980889bec6bfd325ed1dafad34f85242b5a07b60af004742fb
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
@@ -530,6 +542,7 @@ CHECKSUMS
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.1) sha256=7854c74f48e2e975969062833adc4013f249a4b212f5e7b9d5c040bf838d54bb
   msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732
+  multi_xml (0.8.1) sha256=addba0290bac34e9088bfe73dc4878530297a82a7bbd66cb44dcd0a4b86edf5a
   net-imap (0.6.2) sha256=08caacad486853c61676cca0c0c47df93db02abc4a8239a8b67eb0981428acc6
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
@@ -580,6 +593,7 @@ CHECKSUMS
   rdoc (7.0.3) sha256=dfe3d0981d19b7bba71d9dbaeb57c9f4e3a7a4103162148a559c4fc687ea81f9
   regexp_parser (2.11.3) sha256=ca13f381a173b7a93450e53459075c9b76a10433caadcb2f1180f2c741fc55a4
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
+  resend (1.0.0) sha256=b64defd50a1967e8a6ef346b94dab4f1dd76628b36be556866e45db648d60a07
   responders (3.2.0) sha256=89c2d6ac0ae16f6458a11524cae4a8efdceba1a3baea164d28ee9046bd3df55a
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
   rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,29 +1,25 @@
 <p><%= @resource.email %> 様</p>
 
 <p>
-  Futari Log をご利用いただきありがとうございます。
+Futari Log をご利用いただきありがとうございます。
 </p>
 
 <p>
-  パスワード再設定のご依頼を受け付けました。<br>
-  下記のリンクから、新しいパスワードを設定してください。
-</p>
-
-<p style="margin: 24px 0;">
-  <%= link_to "パスワードを再設定する",
-        edit_password_url(@resource, reset_password_token: @token),
-        style: "display:inline-block;padding:12px 20px;background:#14b8a6;color:#fff;text-decoration:none;border-radius:6px;" %>
+以下のリンクから、パスワードの再設定を行ってください。
 </p>
 
 <p>
-  ※このリンクの有効期限は <strong>6時間</strong> です。
+<%= link_to "パスワードを再設定する", edit_password_url(@resource, reset_password_token: @token) %>
 </p>
 
 <p>
-  もしこのメールに心当たりがない場合は、<br>
-  本メールは破棄してください。パスワードは変更されません。
+※ このリンクの有効期限は <strong>6時間</strong> です。<br>
+※ このメールに心当たりがない場合は、破棄してください。
 </p>
 
+<hr>
+
 <p>
-  今後とも Futari Log をよろしくお願いいたします。
+Futari Log<br>
+大切な「気持ち」を、そっと記録するアプリ
 </p>

--- a/app/views/devise/mailer/reset_password_instructions.text.erb
+++ b/app/views/devise/mailer/reset_password_instructions.text.erb
@@ -1,0 +1,14 @@
+<%= @resource.email %> 様
+
+Futari Log をご利用いただきありがとうございます。
+
+以下のURLから、パスワードの再設定を行ってください。
+
+<%= edit_password_url(@resource, reset_password_token: @token) %>
+
+※ このリンクの有効期限は6時間です。
+※ このメールに心当たりがない場合は破棄してください。
+
+--
+Futari Log
+大切な「気持ち」を、そっと記録するアプリ

--- a/compose.yml
+++ b/compose.yml
@@ -27,6 +27,7 @@ services:
       - bundle_data:/usr/local/bundle:cached
       - node_modules:/myapp/node_modules
     environment:
+      MAIL_FROM: "Futari Log <no-reply@resend.dev>"
       TZ: Asia/Tokyo
     ports:
       - "3000:3000"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -18,26 +18,14 @@ Rails.application.configure do
   # Cache assets for far-future expiry since they are all digest stamped.
   config.public_file_server.headers = { "cache-control" => "public, max-age=#{1.year.to_i}" }
 
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.asset_host = "http://assets.example.com"
-
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
-
-  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
-  # config.assume_ssl = true
-
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
-
-  # Skip http-to-https redirect for the default health check endpoint.
-  # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Log to STDOUT with the current request id as a default log tag.
   config.log_tags = [ :request_id ]
   config.logger   = ActiveSupport::TaggedLogging.logger(STDOUT)
 
-  # Change to "debug" to log everything (including potentially personally-identifiable information!).
+  # Log level
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
   # Prevent health checks from clogging up the logs.
@@ -46,56 +34,38 @@ Rails.application.configure do
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
 
-  # Replace the default in-process memory cache store with a durable alternative.
+  # Cache / Job
   config.cache_store = :solid_cache_store
-
-  # Replace the default in-process and non-durable queuing backend for Active Job.
   config.active_job.queue_adapter = :solid_queue
   config.solid_queue.connects_to = { database: { writing: :queue } }
 
-  # === Action Mailer 設定（Gmail SMTP） ==========================
+  # ================== Action Mailer（Resend） ==================
 
-  # メール送信エラーをログに出す（本番では重要）
+  # メール送信エラーを表示（本番では必須）
   config.action_mailer.raise_delivery_errors = true
 
-  # 配送方法を SMTP に指定
-  config.action_mailer.delivery_method = :smtp
+  # Resend を使う
+  config.action_mailer.delivery_method = :resend
 
-  # Gmail SMTP 設定（環境変数使用）
-  config.action_mailer.smtp_settings = {
-    address: "smtp.gmail.com",
-    port: 587,
-    domain: "gmail.com",
-    user_name: ENV["GMAIL_USERNAME"],
-    password: ENV["GMAIL_APP_PASSWORD"],
-    authentication: :plain,
-    enable_starttls_auto: true
-  }
-
-  # Devise のメール内リンク用 URL
+  # メール内リンク用 URL（Devise）
   config.action_mailer.default_url_options = {
     host: "futari-log.onrender.com",
     protocol: "https"
   }
 
-  # =============================================================
+  # ============================================================
 
-  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation cannot be found).
+  # I18n
   config.i18n.fallbacks = true
 
-  # Do not dump schema after migrations.
+  # Active Record
   config.active_record.dump_schema_after_migration = false
-
-  # Only use :id for inspections in production.
   config.active_record.attributes_for_inspect = [ :id ]
 
-  # Enable DNS rebinding protection and other `Host` header attacks.
+  # Host Authorization
   # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
+  #   "example.com",
+  #   /.*\.example\.com/
   # ]
-  #
-  # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end


### PR DESCRIPTION
## 概要
Resend を利用して、Devise のパスワードリセットメール送信機能を実装しました。

## 背景
- SendGrid へのログイン制限により利用が困難になったため
- Gmail SMTP は設定・制限が多く、卒業制作用途には不向きだったため

## 実装内容
- Resend API を利用したメール送信設定を追加
- Action Mailer の delivery_method を Resend に変更
- パスワードリセットメール本文を日本語化
- from アドレスを環境変数管理に統一

## 確認方法
1. パスワードを忘れた場合の画面からメールアドレスを送信
2. 受信したメールのリンクからパスワード再設定が可能なことを確認

## 補足
- ドメイン設定なし（resend.dev）で無料枠のまま運用可能