### PR TITLE
SMTP完全排除

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -33,6 +33,8 @@ Rails.application.configure do
 
   config.action_mailer.raise_delivery_errors = true
 
+  config.action_mailer.delivery_method = :test
+
   config.action_mailer.default_url_options = {
     host: "futari-log.onrender.com",
     protocol: "https"


### PR DESCRIPTION
config/environments/production.rbに
config.action_mailer.delivery_method = :test
を記述し、SMTPを完全排除