### PR TITLE
Resend API を用いた Devise パスワード再設定メール送信に統一

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
 
   config.active_storage.service = :local
 
-  config.log_tags = [:request_id]
+  config.log_tags = [ :request_id ]
   config.logger = ActiveSupport::TaggedLogging.logger(STDOUT)
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
@@ -32,8 +32,7 @@ Rails.application.configure do
   # ------------------------------------------------------------
 
   config.action_mailer.raise_delivery_errors = true
-
-  config.action_mailer.delivery_method = :test
+  config.action_mailer.delivery_method = :resend
 
   config.action_mailer.default_url_options = {
     host: "futari-log.onrender.com",
@@ -46,5 +45,5 @@ Rails.application.configure do
 
   config.i18n.fallbacks = true
   config.active_record.dump_schema_after_migration = false
-  config.active_record.attributes_for_inspect = [:id]
+  config.active_record.attributes_for_inspect = [ :id ]
 end

--- a/config/initializers/resend.rb
+++ b/config/initializers/resend.rb
@@ -1,0 +1,3 @@
+require "resend"
+
+Resend.api_key = ENV.fetch("RESEND_API_KEY")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,12 @@ Rails.application.routes.draw do
   get "tags/create"
   get "moods/create"
   root "home#index"
-  devise_for :users
+  devise_for :users, controllers: {
+    registrations: "users/registrations",
+    sessions: "users/sessions",
+    passwords: "users/passwords",
+    omniauth_callbacks: "users/omniauth_callbacks"
+  }
   # 招待コード発行
   get "invitations/new"
   # 招待コード参加（追加）


### PR DESCRIPTION
## 概要
Devise のパスワード再設定メール送信を Resend API を用いた方式に統一しました。

SMTP 設定が混在していたため、Qiita 記事の成功例に合わせて
Resend gem を利用した最小構成へ修正しています。

## 変更内容
- resend gem を追加
- Resend API 用 initializer を追加
- ActionMailer の delivery_method を :resend に変更
- SMTP 関連設定を完全に削除
- Devise の mailer_sender を環境変数参照に統一
- devise_for の controllers 指定を明示化

## 環境変数
- RESEND_API_KEY
- MAIL_FROM

## 動作確認
- パスワード再設定リクエスト時に 500 エラーが発生しないこと
- Devise のフローが正常に完了すること