### PR TITLE
簡易管理画面（admin）を追加

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,0 +1,34 @@
+class AdminController < ApplicationController
+  before_action :authenticate_user!
+  before_action :admin_only
+
+  def index
+    @users_count = User.count
+    @moods_count = Mood.count
+    @thanks_count = Thank.count
+  end
+
+  def users
+    @users = User.order(created_at: :desc)
+  end
+
+  def moods
+    @moods = Mood.includes(:user).order(recorded_on: :desc)
+  end
+
+  def thanks
+    @thanks = Thank.includes(:sender, :receiver).order(created_at: :desc)
+  end
+
+  def destroy_user
+    user = User.find(params[:id])
+    user.destroy
+    redirect_to "/admin/users", notice: "ユーザーを削除しました"
+  end
+
+  private
+
+  def admin_only
+    redirect_to root_path unless current_user.email == "m20007755@docomo.ne.jp"
+  end
+end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -1,0 +1,2 @@
+module AdminHelper
+end

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -1,0 +1,13 @@
+<h1>管理画面</h1>
+
+<p>ユーザー数: <%= @users_count %></p>
+<p>Mood数: <%= @moods_count %></p>
+<p>Thanks数: <%= @thanks_count %></p>
+
+<hr>
+
+<ul>
+  <li><%= link_to "ユーザー一覧", "/admin/users" %></li>
+  <li><%= link_to "Mood一覧", "/admin/moods" %></li>
+  <li><%= link_to "Thanks一覧", "/admin/thanks" %></li>
+</ul>

--- a/app/views/admin/moods.html.erb
+++ b/app/views/admin/moods.html.erb
@@ -1,0 +1,19 @@
+<h1>Mood一覧</h1>
+
+<table border="1">
+  <tr>
+    <th>ID</th>
+    <th>User</th>
+    <th>Level</th>
+    <th>Recorded On</th>
+  </tr>
+
+  <% @moods.each do |mood| %>
+    <tr>
+      <td><%= mood.id %></td>
+      <td><%= mood.user.email %></td>
+      <td><%= mood.level %></td>
+      <td><%= mood.recorded_on %></td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/admin/thanks.html.erb
+++ b/app/views/admin/thanks.html.erb
@@ -1,0 +1,19 @@
+<h1>Thanks一覧</h1>
+
+<table border="1">
+  <tr>
+    <th>ID</th>
+    <th>Sender</th>
+    <th>Receiver</th>
+    <th>Created</th>
+  </tr>
+
+  <% @thanks.each do |thank| %>
+    <tr>
+      <td><%= thank.id %></td>
+      <td><%= thank.sender.email %></td>
+      <td><%= thank.receiver.email %></td>
+      <td><%= thank.created_at %></td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/admin/users.html.erb
+++ b/app/views/admin/users.html.erb
@@ -1,0 +1,26 @@
+<h1>ユーザー一覧</h1>
+
+<table border="1">
+  <tr>
+    <th>ID</th>
+    <th>Email</th>
+    <th>Nickname</th>
+    <th>Created</th>
+    <th></th>
+  </tr>
+
+  <% @users.each do |user| %>
+    <tr>
+      <td><%= user.id %></td>
+      <td><%= user.email %></td>
+      <td><%= user.nickname %></td>
+      <td><%= user.created_at %></td>
+      <td>
+        <%= button_to "削除",
+            "/admin/users/#{user.id}",
+            method: :delete,
+            data: { confirm: "本当に削除しますか？" } %>
+      </td>
+    </tr>
+  <% end %>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get "admin/index"
   get "notification_settings/edit"
   get "notification_settings/update"
   get "notifications/index"
@@ -64,4 +65,9 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "posts#index"
+  get "admin", to: "admin#index"
+  get "admin/users", to: "admin#users"
+  get "admin/moods", to: "admin#moods"
+  get "admin/thanks", to: "admin#thanks"
+  delete "admin/users/:id", to: "admin#destroy_user"
 end

--- a/test/controllers/admin_controller_test.rb
+++ b/test/controllers/admin_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class AdminControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get admin_index_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要

本番環境のデータ確認およびデバッグを容易にするため、
簡易的な管理画面を追加しました。

Render無料プランではShellが利用できないため、
ユーザーやmoodなどのデータを確認する手段として実装しています。

## 実装内容

- 管理画面トップ `/admin`
- ユーザー一覧 `/admin/users`
- mood一覧 `/admin/moods`
- thanks一覧 `/admin/thanks`
- ユーザー削除機能

## 管理画面のアクセス制御

ログインユーザーのうち、
特定メールアドレスのみアクセス可能としています。

## 確認方法

ログイン後

/admin

へアクセスすると管理画面が表示されます。

## 目的

- 本番データの確認
- 不具合調査
- Render無料プランでのDB確認